### PR TITLE
chore: add CI, Codeowners, and issue/PR templates

### DIFF
--- a/.config/nextest.toml
+++ b/.config/nextest.toml
@@ -1,0 +1,12 @@
+# recommended nextest profile for CI jobs (from
+# https://nexte.st/book/configuration.html#profiles)
+[profile.ci]
+# Print out output for failing tests as soon as they fail, and also at the end
+# of the run (for easy scrollability).
+failure-output = "immediate-final"
+# Do not cancel the test run on the first failure.
+fail-fast = false
+
+# TODO(eliza): uncomment this when we can get nicer JUnit output from nextest...
+# [profile.ci.junit]
+# path = "junit.xml"

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,1 @@
-* @jatescher
+* @jtescher

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @jatescher

--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,51 @@
+---
+name: 🐛 Bug Report
+about: If something isn't working as expected 🤔.
+
+---
+
+## Bug Report
+<!--
+Thank you for reporting an issue.
+
+Please fill in as much of the template below as you're able.
+-->
+
+### Version
+
+<!--
+List the versions of all `tracing` crates you are using. The easiest way to get
+this information is using `cargo-tree`.
+
+`cargo install cargo-tree`
+(see install here: https://github.com/sfackler/cargo-tree)
+
+Then:
+
+`cargo tree | grep tracing`
+-->
+
+### Platform
+
+<!---
+Output of `uname -a` (UNIX), or version and 32 or 64-bit (Windows)
+-->
+
+### Description
+
+<!--
+
+Enter your issue details below this comment.
+
+One way to structure the description:
+
+<short summary of the bug>
+
+I tried this code:
+
+<code sample that causes the bug>
+
+I expected to see this happen: <explanation>
+
+Instead, this happened: <explanation>
+-->

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,28 @@
+---
+name: 💡 Feature Request
+about: I have a suggestion (and may want to implement it 🙂)!
+
+---
+
+## Feature Request
+
+### Motivation
+
+<!--
+Please describe the use case(s) or other motivation for the new feature.
+-->
+
+### Proposal
+
+<!--
+How should the new feature be implemented, and why? Add any considered
+drawbacks.
+-->
+
+### Alternatives
+
+<!--
+Are there other ways to solve this problem that you've considered? What are
+their potential drawbacks? Why was the proposed solution chosen over these
+alternatives?
+-->

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,23 @@
+<!--
+Thank you for your Pull Request. Please provide a description above and review
+the requirements below.
+
+Bug fixes and new features should include tests.
+
+Contributors guide: https://github.com/tokio-rs/tracing-opentelemetry/blob/master/CONTRIBUTING.md
+-->
+
+## Motivation
+
+<!--
+Explain the context and why you're making that change. What is the problem
+you're trying to solve? If a new feature is being added, describe the intended
+use case that feature fulfills.
+-->
+
+## Solution
+
+<!--
+Summarize the solution and provide any necessary context needed to understand
+the code change.
+-->

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,14 @@
+version: 2
+updates:
+- package-ecosystem: cargo
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10
+  ignore:
+  - dependency-name: opentelemetry-jaeger
+    versions:
+    - 0.12.0
+  - dependency-name: opentelemetry
+    versions:
+    - 0.13.0

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,7 +77,7 @@ jobs:
     - uses: dtolnay/rust-toolchain@stable
     - name: install cargo-hack
       uses: taiki-e/install-action@cargo-hack
-    - name: cargo hack check --feature-powerset --no-dev-deps
+    - run: cargo hack check --feature-powerset --no-dev-deps
 
   check-msrv:
     # Run `cargo check` on our minimum supported Rust version (1.56.0). This

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -1,0 +1,218 @@
+name: CI
+
+on:
+  push:
+    branches:
+    - master
+  pull_request: {}
+
+env:
+  # Disable incremental compilation.
+  #
+  # Incremental compilation is useful as part of an edit-build-test-edit cycle,
+  # as it lets the compiler avoid recompiling code that hasn't changed. However,
+  # on CI, we're not making small edits; we're almost always building the entire
+  # project from scratch. Thus, incremental compilation on CI actually
+  # introduces *additional* overhead to support making future builds
+  # faster...but no future builds will ever occur in any given CI environment.
+  #
+  # See https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow
+  # for details.
+  CARGO_INCREMENTAL: 0
+  # Allow more retries for network requests in cargo (downloading crates) and
+  # rustup (installing toolchains). This should help to reduce flaky CI failures
+  # from transient network timeouts or other issues.
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  # Don't emit giant backtraces in the CI logs.
+  RUST_BACKTRACE: short
+
+jobs:
+  ### check jobs ###
+
+  check:
+    # Run `cargo check` first to ensure that the pushed code at least compiles.
+    name: cargo check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+    - name: Check
+      run: cargo check --all --tests --benches
+
+  style:
+    # Check style.
+    name: cargo fmt
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: rustfmt
+    - name: rustfmt
+      run: cargo fmt --all -- --check
+
+  warnings:
+    # Check for any warnings. This is informational and thus is allowed to fail.
+    runs-on: ubuntu-latest
+    needs: check
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        components: clippy
+    - name: Clippy
+      uses: actions-rs/clippy-check@v1
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        args: --all --examples --tests --benches -- -D warnings
+
+  cargo-hack:
+    needs: check
+    name: cargo check (feature combinations)
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        # cargo hack --feature-powerset will have a significant permutation
+        # number, we can't just use --all as it increases the runtime
+        # further than what we would like to
+        subcrate:
+        - tracing-attributes
+        - tracing-core
+        - tracing-futures
+        - tracing-log
+        - tracing-macros
+        - tracing-serde
+        - tracing-tower
+        - tracing-opentelemetry
+        - tracing
+        - tracing-subscriber
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+
+    - name: install cargo-hack
+      uses: taiki-e/install-action@cargo-hack
+    - name: cargo hack check
+      working-directory: ${{ matrix.subcrate }}
+      # tracing and tracing-subscriber have too many features to be checked by
+      # cargo-hack --feature-powerset with all features in the powerset, so
+      # exclude some
+      run: |
+        CARGO_HACK=(cargo hack check --feature-powerset --no-dev-deps)
+        case "${{ matrix.subcrate }}" in
+          tracing)
+            EXCLUDE_FEATURES=(
+              max_level_off max_level_error max_level_warn max_level_info
+              max_level_debug max_level_trace release_max_level_off
+              release_max_level_error release_max_level_warn
+              release_max_level_info release_max_level_debug
+              release_max_level_trace
+            )
+            ${CARGO_HACK[@]} --exclude-features "${EXCLUDE_FEATURES[*]}"
+            ;;
+          tracing-subscriber)
+            INCLUDE_FEATURES=(fmt ansi json registry env-filter)
+            ${CARGO_HACK[@]} --include-features "${INCLUDE_FEATURES[*]}"
+            ;;
+          *)
+            ${CARGO_HACK[@]}
+            ;;
+        esac
+      shell: bash
+
+  check-msrv:
+    # Run `cargo check` on our minimum supported Rust version (1.56.0). This
+    # checks with minimal versions; maximal versions are checked above.
+    name: "cargo check (+MSRV -Zminimal-versions)"
+    needs: check
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        toolchain:
+        - 1.56.0
+        - stable
+    steps:
+    - uses: actions/checkout@v3
+    - name: install Rust nightly
+      uses: dtolnay/rust-toolchain@nightly
+    - name: "install Rust ${{ matrix.toolchain }}"
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.toolchain }}
+    - name: install cargo-hack
+      uses: taiki-e/install-action@cargo-hack
+    - name: install cargo-minimal-versions
+      uses: taiki-e/install-action@cargo-minimal-versions
+    - name: cargo minimal-versions check
+      working-directory: ${{ matrix.subcrate }}
+      run: cargo minimal-versions check --feature-powerset --no-dev-deps
+
+  ### test jobs #############################################################
+
+  test:
+    # Test against stable Rust across macOS, Windows, and Linux, and against
+    # beta and nightly rust on Ubuntu.
+    name: "cargo test (${{ matrix.rust }} on ${{ matrix.os }})"
+    needs: check
+    strategy:
+      matrix:
+        # test all Rust versions on ubuntu-latest
+        os: [ubuntu-latest]
+        rust: [stable, beta, nightly]
+        # test stable Rust on Windows and MacOS as well
+        include:
+          - rust: stable
+            os: windows-latest
+          - rust: stable
+            os: macos-latest
+      fail-fast: false
+    runs-on: ${{ matrix.os }}
+    steps:
+    - uses: actions/checkout@v3
+    - name: "install Rust ${{ matrix.rust }}"
+      uses: dtolnay/rust-toolchain@master
+      with:
+        toolchain: ${{ matrix.rust }}
+    - name: install cargo-nextest
+      uses: taiki-e/install-action@nextest
+    - name: Run tests
+      run: cargo nextest run --profile ci --workspace
+    # TODO(eliza): punt on this for now because the generated JUnit report is
+    # missing some fields that this action needs to give good output.
+    # - name: Publish Test Report
+    #   uses: mikepenz/action-junit-report@v3
+    #   if: always() # always run even if the previous step fails
+    #   with:
+    #     report_paths: 'target/nextest/ci/junit.xml'
+    #     check_name: "cargo test (Rust ${{ matrix.rust }} on ${{ matrix.os }})"
+    #     check_title_template: "{{SUITE_NAME}}::{{TEST_NAME}}"
+    - name: Run doctests
+      run: cargo test --doc --workspace
+
+  test-build-wasm:
+    name: build tests (wasm)
+    needs: check
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - uses: dtolnay/rust-toolchain@stable
+      with:
+        target: wasm32-unknown-unknown
+    - name: build all tests
+      run: cargo test --no-run
+
+  # all required checks except for the main test run (which we only require
+  # specific matrix combinations from)
+  all_required:
+    name: "all systems go!"
+    runs-on: ubuntu-latest
+    needs:
+      - style
+      - cargo-hack
+      - check-msrv
+      - test-build-wasm
+      - test
+    steps:
+      - run: exit 0

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -72,55 +72,12 @@ jobs:
     needs: check
     name: cargo check (feature combinations)
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        # cargo hack --feature-powerset will have a significant permutation
-        # number, we can't just use --all as it increases the runtime
-        # further than what we would like to
-        subcrate:
-        - tracing-attributes
-        - tracing-core
-        - tracing-futures
-        - tracing-log
-        - tracing-macros
-        - tracing-serde
-        - tracing-tower
-        - tracing-opentelemetry
-        - tracing
-        - tracing-subscriber
     steps:
     - uses: actions/checkout@v3
     - uses: dtolnay/rust-toolchain@stable
-
     - name: install cargo-hack
       uses: taiki-e/install-action@cargo-hack
-    - name: cargo hack check
-      working-directory: ${{ matrix.subcrate }}
-      # tracing and tracing-subscriber have too many features to be checked by
-      # cargo-hack --feature-powerset with all features in the powerset, so
-      # exclude some
-      run: |
-        CARGO_HACK=(cargo hack check --feature-powerset --no-dev-deps)
-        case "${{ matrix.subcrate }}" in
-          tracing)
-            EXCLUDE_FEATURES=(
-              max_level_off max_level_error max_level_warn max_level_info
-              max_level_debug max_level_trace release_max_level_off
-              release_max_level_error release_max_level_warn
-              release_max_level_info release_max_level_debug
-              release_max_level_trace
-            )
-            ${CARGO_HACK[@]} --exclude-features "${EXCLUDE_FEATURES[*]}"
-            ;;
-          tracing-subscriber)
-            INCLUDE_FEATURES=(fmt ansi json registry env-filter)
-            ${CARGO_HACK[@]} --include-features "${INCLUDE_FEATURES[*]}"
-            ;;
-          *)
-            ${CARGO_HACK[@]}
-            ;;
-        esac
-      shell: bash
+    - name: cargo hack check --feature-powerset --no-dev-deps
 
   check-msrv:
     # Run `cargo check` on our minimum supported Rust version (1.56.0). This

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,35 @@
+name: Security audit
+
+on:
+  schedule:
+    - cron: '0 0 * * *'
+
+env:
+  # Disable incremental compilation.
+  #
+  # Incremental compilation is useful as part of an edit-build-test-edit cycle,
+  # as it lets the compiler avoid recompiling code that hasn't changed. However,
+  # on CI, we're not making small edits; we're almost always building the entire
+  # project from scratch. Thus, incremental compilation on CI actually
+  # introduces *additional* overhead to support making future builds
+  # faster...but no future builds will ever occur in any given CI environment.
+  #
+  # See https://matklad.github.io/2021/09/04/fast-rust-builds.html#ci-workflow
+  # for details.
+  CARGO_INCREMENTAL: 0
+  # Allow more retries for network requests in cargo (downloading crates) and
+  # rustup (installing toolchains). This should help to reduce flaky CI failures
+  # from transient network timeouts or other issues.
+  CARGO_NET_RETRY: 10
+  RUSTUP_MAX_RETRIES: 10
+  # Don't emit giant backtraces in the CI logs.
+  RUST_BACKTRACE: short
+
+jobs:
+  security_audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions-rs/audit-check@v1
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,22 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - v[0-9]+.*
+
+jobs:
+  create-release:
+    name: Create GitHub release
+    # only publish from the origin repository
+    if: github.repository_owner == 'tokio-rs'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: taiki-e/create-gh-release-action@v1
+        with:
+          changelog: "CHANGELOG.md"
+          title: "$version"
+          branch: v0.1.x
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
These are mostly copied over from `tokio-rs/tracing`, with
modifications (removing builds for other crates, etc).