### PR TITLE
chore: Update website on Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,7 +6,7 @@ authors = [
     "Tokio Contributors <team@tokio.rs>"
 ]
 description = "OpenTelemetry integration for tracing"
-homepage = "https://github.com/tokio-rs/tracing/tree/master/tracing-opentelemetry"
+homepage = "https://github.com/tokio-rs/tracing-opentelemetry"
 repository = "https://github.com/tokio-rs/tracing"
 readme = "README.md"
 categories = [


### PR DESCRIPTION
Hi there, this is just to update the website because on crates.io it still points to tokio's repository
