### PR TITLE
fix: Backport opentelemetry 0.18 code from main repo

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ categories = [
 keywords = ["tracing", "opentelemetry", "jaeger", "zipkin", "async"]
 license = "MIT"
 edition = "2018"
-rust-version = "1.46.0"
+rust-version = "1.56.0"
 
 [features]
 default = ["tracing-log", "metrics"]
@@ -25,7 +25,7 @@ default = ["tracing-log", "metrics"]
 metrics = ["opentelemetry/metrics"]
 
 [dependencies]
-opentelemetry = { version = "0.17.0", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.18.0", default-features = false, features = ["trace"] }
 tracing = { version = "0.1.35", default-features = false, features = ["std"] }
 tracing-core = "0.1.28"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
@@ -39,7 +39,7 @@ thiserror = { version = "1.0.31", optional = true }
 [dev-dependencies]
 async-trait = "0.1.56"
 criterion = { version = "0.3.6", default-features = false }
-opentelemetry-jaeger = "0.16.0"
+opentelemetry-jaeger = "0.17.0"
 futures-util = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ The crate provides the following types:
 [`tracing`]: https://crates.io/crates/tracing
 [OpenTelemetry]: https://opentelemetry.io/
 
-*Compiler support: [requires `rustc` 1.49+][msrv]*
+*Compiler support: [requires `rustc` 1.56+][msrv]*
 
 [msrv]: #supported-rust-versions
 
@@ -110,7 +110,7 @@ $ firefox http://localhost:16686/
 ## Supported Rust Versions
 
 Tracing Opentelemetry is built against the latest stable release. The minimum
-supported version is 1.46. The current Tracing version is not guaranteed to
+supported version is 1.56. The current Tracing version is not guaranteed to
 build on Rust versions earlier than the minimum supported version.
 
 Tracing follows the same compiler support policies as the rest of the Tokio

--- a/examples/opentelemetry.rs
+++ b/examples/opentelemetry.rs
@@ -18,7 +18,7 @@ fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
     // Install an otel pipeline with a simple span processor that exports data one at a time when
     // spans end. See the `install_batch` option on each exporter's pipeline builder to see how to
     // export in batches.
-    let tracer = opentelemetry_jaeger::new_pipeline()
+    let tracer = opentelemetry_jaeger::new_agent_pipeline()
         .with_service_name("report_example")
         .install_simple()?;
     let opentelemetry = tracing_opentelemetry::layer().with_tracer(tracer);

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,11 +1,10 @@
 use crate::{OtelData, PreSampledTracer};
 use once_cell::unsync;
 use opentelemetry::{
-    trace::{self as otel, noop, TraceContextExt},
-    Context as OtelContext, Key, KeyValue, Value,
+    trace::{self as otel, noop, OrderMap, TraceContextExt},
+    Context as OtelContext, Key, KeyValue, StringValue, Value,
 };
 use std::any::TypeId;
-use std::borrow::Cow;
 use std::fmt;
 use std::marker;
 use std::thread;
@@ -106,12 +105,11 @@ fn str_to_span_kind(s: &str) -> Option<otel::SpanKind> {
     }
 }
 
-fn str_to_status_code(s: &str) -> Option<otel::StatusCode> {
+fn str_to_status(s: &str) -> otel::Status {
     match s {
-        s if s.eq_ignore_ascii_case("unset") => Some(otel::StatusCode::Unset),
-        s if s.eq_ignore_ascii_case("ok") => Some(otel::StatusCode::Ok),
-        s if s.eq_ignore_ascii_case("error") => Some(otel::StatusCode::Error),
-        _ => None,
+        s if s.eq_ignore_ascii_case("ok") => otel::Status::Ok,
+        s if s.eq_ignore_ascii_case("error") => otel::Status::error(""),
+        _ => otel::Status::Unset,
     }
 }
 
@@ -217,11 +215,11 @@ impl<'a, 'b> field::Visit for SpanEventVisitor<'a, 'b> {
         field: &tracing_core::Field,
         value: &(dyn std::error::Error + 'static),
     ) {
-        let mut chain = Vec::new();
+        let mut chain: Vec<StringValue> = Vec::new();
         let mut next_err = value.source();
 
         while let Some(err) = next_err {
-            chain.push(Cow::Owned(err.to_string()));
+            chain.push(err.to_string().into());
             next_err = err.source();
         }
 
@@ -246,7 +244,10 @@ impl<'a, 'b> field::Visit for SpanEventVisitor<'a, 'b> {
         if self.exception_config.propagate {
             if let Some(span) = &mut self.span_builder {
                 if let Some(attrs) = span.attributes.as_mut() {
-                    attrs.push(Key::new(FIELD_EXCEPTION_MESSAGE).string(error_msg.clone()));
+                    attrs.insert(
+                        Key::new(FIELD_EXCEPTION_MESSAGE),
+                        Value::String(error_msg.clone().into()),
+                    );
 
                     // NOTE: This is actually not the stacktrace of the exception. This is
                     // the "source chain". It represents the heirarchy of errors from the
@@ -254,7 +255,10 @@ impl<'a, 'b> field::Visit for SpanEventVisitor<'a, 'b> {
                     // of the callsites in the code that led to the error happening.
                     // `std::error::Error::backtrace` is a nightly-only API and cannot be
                     // used here until the feature is stabilized.
-                    attrs.push(Key::new(FIELD_EXCEPTION_STACKTRACE).array(chain.clone()));
+                    attrs.insert(
+                        Key::new(FIELD_EXCEPTION_STACKTRACE),
+                        Value::Array(chain.clone().into()),
+                    );
                 }
             }
         }
@@ -289,7 +293,7 @@ impl<'a> SpanAttributeVisitor<'a> {
     fn record(&mut self, attribute: KeyValue) {
         debug_assert!(self.span_builder.attributes.is_some());
         if let Some(v) = self.span_builder.attributes.as_mut() {
-            v.push(attribute);
+            v.insert(attribute.key, attribute.value);
         }
     }
 }
@@ -323,9 +327,9 @@ impl<'a> field::Visit for SpanAttributeVisitor<'a> {
         match field.name() {
             SPAN_NAME_FIELD => self.span_builder.name = value.to_string().into(),
             SPAN_KIND_FIELD => self.span_builder.span_kind = str_to_span_kind(value),
-            SPAN_STATUS_CODE_FIELD => self.span_builder.status_code = str_to_status_code(value),
+            SPAN_STATUS_CODE_FIELD => self.span_builder.status = str_to_status(value),
             SPAN_STATUS_MESSAGE_FIELD => {
-                self.span_builder.status_message = Some(value.to_owned().into())
+                self.span_builder.status = otel::Status::error(value.to_string())
             }
             _ => self.record(KeyValue::new(field.name(), value.to_string())),
         }
@@ -342,10 +346,10 @@ impl<'a> field::Visit for SpanAttributeVisitor<'a> {
                 self.span_builder.span_kind = str_to_span_kind(&format!("{:?}", value))
             }
             SPAN_STATUS_CODE_FIELD => {
-                self.span_builder.status_code = str_to_status_code(&format!("{:?}", value))
+                self.span_builder.status = str_to_status(&format!("{:?}", value))
             }
             SPAN_STATUS_MESSAGE_FIELD => {
-                self.span_builder.status_message = Some(format!("{:?}", value).into())
+                self.span_builder.status = otel::Status::error(format!("{:?}", value))
             }
             _ => self.record(Key::new(field.name()).string(format!("{:?}", value))),
         }
@@ -360,11 +364,11 @@ impl<'a> field::Visit for SpanAttributeVisitor<'a> {
         field: &tracing_core::Field,
         value: &(dyn std::error::Error + 'static),
     ) {
-        let mut chain = Vec::new();
+        let mut chain: Vec<StringValue> = Vec::new();
         let mut next_err = value.source();
 
         while let Some(err) = next_err {
-            chain.push(Cow::Owned(err.to_string()));
+            chain.push(err.to_string().into());
             next_err = err.source();
         }
 
@@ -406,7 +410,7 @@ where
     /// use tracing_subscriber::Registry;
     ///
     /// // Create a jaeger exporter pipeline for a `trace_demo` service.
-    /// let tracer = opentelemetry_jaeger::new_pipeline()
+    /// let tracer = opentelemetry_jaeger::new_agent_pipeline()
     ///     .with_service_name("trace_demo")
     ///     .install_simple()
     ///     .expect("Error initializing Jaeger exporter");
@@ -447,7 +451,7 @@ where
     /// use tracing_subscriber::Registry;
     ///
     /// // Create a jaeger exporter pipeline for a `trace_demo` service.
-    /// let tracer = opentelemetry_jaeger::new_pipeline()
+    /// let tracer = opentelemetry_jaeger::new_agent_pipeline()
     ///     .with_service_name("trace_demo")
     ///     .install_simple()
     ///     .expect("Error initializing Jaeger exporter");
@@ -685,7 +689,7 @@ where
             builder.trace_id = Some(self.tracer.new_trace_id());
         }
 
-        let builder_attrs = builder.attributes.get_or_insert(Vec::with_capacity(
+        let builder_attrs = builder.attributes.get_or_insert(OrderMap::with_capacity(
             attrs.fields().len() + self.extra_span_attrs(),
         ));
 
@@ -693,26 +697,26 @@ where
             let meta = attrs.metadata();
 
             if let Some(filename) = meta.file() {
-                builder_attrs.push(KeyValue::new("code.filepath", filename));
+                builder_attrs.insert("code.filepath".into(), filename.into());
             }
 
             if let Some(module) = meta.module_path() {
-                builder_attrs.push(KeyValue::new("code.namespace", module));
+                builder_attrs.insert("code.namespace".into(), module.into());
             }
 
             if let Some(line) = meta.line() {
-                builder_attrs.push(KeyValue::new("code.lineno", line as i64));
+                builder_attrs.insert("code.lineno".into(), (line as i64).into());
             }
         }
 
         if self.with_threads {
-            THREAD_ID.with(|id| builder_attrs.push(KeyValue::new("thread.id", **id as i64)));
+            THREAD_ID.with(|id| builder_attrs.insert("thread.id".into(), (**id as i64).into()));
             if let Some(name) = std::thread::current().name() {
                 // TODO(eliza): it's a bummer that we have to allocate here, but
                 // we can't easily get the string as a `static`. it would be
                 // nice if `opentelemetry` could also take `Arc<str>`s as
                 // `String` values...
-                builder_attrs.push(KeyValue::new("thread.name", name.to_owned()));
+                builder_attrs.insert("thread.name".into(), name.to_owned().into());
             }
         }
 
@@ -846,8 +850,10 @@ where
             });
 
             if let Some(OtelData { builder, .. }) = extensions.get_mut::<OtelData>() {
-                if builder.status_code.is_none() && *meta.level() == tracing_core::Level::ERROR {
-                    builder.status_code = Some(otel::StatusCode::Error);
+                if builder.status == otel::Status::Unset
+                    && *meta.level() == tracing_core::Level::ERROR
+                {
+                    builder.status = otel::Status::error("")
                 }
 
                 if self.location {
@@ -905,15 +911,14 @@ where
             if self.tracked_inactivity {
                 // Append busy/idle timings when enabled.
                 if let Some(timings) = extensions.get_mut::<Timings>() {
-                    let busy_ns = KeyValue::new("busy_ns", timings.busy);
-                    let idle_ns = KeyValue::new("idle_ns", timings.idle);
+                    let busy_ns = Key::new("busy_ns");
+                    let idle_ns = Key::new("idle_ns");
 
-                    if let Some(ref mut attributes) = builder.attributes {
-                        attributes.push(busy_ns);
-                        attributes.push(idle_ns);
-                    } else {
-                        builder.attributes = Some(vec![busy_ns, idle_ns]);
-                    }
+                    let attributes = builder
+                        .attributes
+                        .get_or_insert_with(|| OrderMap::with_capacity(2));
+                    attributes.insert(busy_ns, timings.busy.into());
+                    attributes.insert(idle_ns, timings.idle.into());
                 }
             }
 
@@ -966,7 +971,7 @@ fn thread_id_integer(id: thread::ThreadId) -> u64 {
 mod tests {
     use super::*;
     use crate::OtelData;
-    use opentelemetry::trace::{noop, SpanKind, TraceFlags};
+    use opentelemetry::trace::{noop, TraceFlags};
     use std::{
         borrow::Cow,
         collections::HashMap,
@@ -1044,7 +1049,7 @@ mod tests {
             false
         }
         fn set_attribute(&mut self, _attribute: KeyValue) {}
-        fn set_status(&mut self, _code: otel::StatusCode, _message: String) {}
+        fn set_status(&mut self, _status: otel::Status) {}
         fn update_name<T: Into<Cow<'static, str>>>(&mut self, _new_name: T) {}
         fn end_with_timestamp(&mut self, _timestamp: SystemTime) {}
     }
@@ -1088,6 +1093,16 @@ mod tests {
         tracing::subscriber::with_default(subscriber, || {
             tracing::debug_span!("static_name", otel.name = dynamic_name.as_str());
         });
+        let recorded_status = tracer
+            .0
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .builder
+            .status
+            .clone();
+        assert_eq!(recorded_status, otel::Status::Unset);
 
         let recorded_name = tracer
             .0
@@ -1104,7 +1119,7 @@ mod tests {
         let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
 
         tracing::subscriber::with_default(subscriber, || {
-            tracing::debug_span!("request", otel.kind = %SpanKind::Server);
+            tracing::debug_span!("request", otel.kind = "server");
         });
 
         let recorded_kind = tracer.with_data(|data| data.builder.span_kind.clone());
@@ -1117,11 +1132,11 @@ mod tests {
         let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
 
         tracing::subscriber::with_default(subscriber, || {
-            tracing::debug_span!("request", otel.status_code = ?otel::StatusCode::Ok);
+            tracing::debug_span!("request", otel.status_code = ?otel::Status::Ok);
         });
 
-        let recorded_status_code = tracer.with_data(|data| data.builder.status_code);
-        assert_eq!(recorded_status_code, Some(otel::StatusCode::Ok))
+        let recorded_status = tracer.with_data(|data| data.builder.status.clone());
+        assert_eq!(recorded_status, otel::Status::Ok)
     }
 
     #[test]
@@ -1135,8 +1150,17 @@ mod tests {
             tracing::debug_span!("request", otel.status_message = message);
         });
 
-        let recorded_status_message = tracer.with_data(|data| data.builder.status_message.clone());
-        assert_eq!(recorded_status_message, Some(message.into()))
+        let recorded_status_message = tracer
+            .0
+            .lock()
+            .unwrap()
+            .as_ref()
+            .unwrap()
+            .builder
+            .status
+            .clone();
+
+        assert_eq!(recorded_status_message, otel::Status::error(message))
     }
 
     #[test]
@@ -1154,7 +1178,7 @@ mod tests {
         let _g = existing_cx.attach();
 
         tracing::subscriber::with_default(subscriber, || {
-            tracing::debug_span!("request", otel.kind = %SpanKind::Server);
+            tracing::debug_span!("request", otel.kind = "server");
         });
 
         let recorded_trace_id =
@@ -1178,7 +1202,7 @@ mod tests {
         let attributes = tracer.with_data(|data| data.builder.attributes.as_ref().unwrap().clone());
         let keys = attributes
             .iter()
-            .map(|attr| attr.key.as_str())
+            .map(|(key, _)| key.as_str())
             .collect::<Vec<&str>>();
         assert!(keys.contains(&"idle_ns"));
         assert!(keys.contains(&"busy_ns"));
@@ -1218,7 +1242,7 @@ mod tests {
 
         let key_values = attributes
             .into_iter()
-            .map(|attr| (attr.key.as_str().to_owned(), attr.value))
+            .map(|(key, value)| (key.as_str().to_owned(), value))
             .collect::<HashMap<_, _>>();
 
         assert_eq!(key_values["error"].as_str(), "user error");
@@ -1226,8 +1250,8 @@ mod tests {
             key_values["error.chain"],
             Value::Array(
                 vec![
-                    Cow::Borrowed("intermediate error"),
-                    Cow::Borrowed("base error")
+                    StringValue::from("intermediate error"),
+                    StringValue::from("base error")
                 ]
                 .into()
             )
@@ -1238,8 +1262,8 @@ mod tests {
             key_values[FIELD_EXCEPTION_STACKTRACE],
             Value::Array(
                 vec![
-                    Cow::Borrowed("intermediate error"),
-                    Cow::Borrowed("base error")
+                    StringValue::from("intermediate error"),
+                    StringValue::from("base error")
                 ]
                 .into()
             )
@@ -1259,7 +1283,7 @@ mod tests {
         let attributes = tracer.with_data(|data| data.builder.attributes.as_ref().unwrap().clone());
         let keys = attributes
             .iter()
-            .map(|attr| attr.key.as_str())
+            .map(|(key, _)| key.as_str())
             .collect::<Vec<&str>>();
         assert!(keys.contains(&"code.filepath"));
         assert!(keys.contains(&"code.namespace"));
@@ -1279,7 +1303,7 @@ mod tests {
         let attributes = tracer.with_data(|data| data.builder.attributes.as_ref().unwrap().clone());
         let keys = attributes
             .iter()
-            .map(|attr| attr.key.as_str())
+            .map(|(key, _)| key.as_str())
             .collect::<Vec<&str>>();
         assert!(!keys.contains(&"code.filepath"));
         assert!(!keys.contains(&"code.namespace"));
@@ -1291,7 +1315,7 @@ mod tests {
         let thread = thread::current();
         let expected_name = thread
             .name()
-            .map(|name| Value::String(Cow::Owned(name.to_owned())));
+            .map(|name| Value::String(name.to_owned().into()));
         let expected_id = Value::I64(thread_id_integer(thread.id()) as i64);
 
         let tracer = TestTracer(Arc::new(Mutex::new(None)));
@@ -1305,7 +1329,7 @@ mod tests {
         let attributes = tracer
             .with_data(|data| data.builder.attributes.as_ref().unwrap().clone())
             .drain(..)
-            .map(|keyval| (keyval.key.as_str().to_string(), keyval.value))
+            .map(|(key, value)| (key.as_str().to_string(), value))
             .collect::<HashMap<_, _>>();
         assert_eq!(attributes.get("thread.name"), expected_name.as_ref());
         assert_eq!(attributes.get("thread.id"), Some(&expected_id));
@@ -1324,7 +1348,7 @@ mod tests {
         let attributes = tracer.with_data(|data| data.builder.attributes.as_ref().unwrap().clone());
         let keys = attributes
             .iter()
-            .map(|attr| attr.key.as_str())
+            .map(|(key, _)| key.as_str())
             .collect::<Vec<&str>>();
         assert!(!keys.contains(&"thread.name"));
         assert!(!keys.contains(&"thread.id"));
@@ -1366,7 +1390,7 @@ mod tests {
 
         let key_values = attributes
             .into_iter()
-            .map(|attr| (attr.key.as_str().to_owned(), attr.value))
+            .map(|(key, value)| (key.as_str().to_owned(), value))
             .collect::<HashMap<_, _>>();
 
         assert_eq!(key_values[FIELD_EXCEPTION_MESSAGE].as_str(), "user error");
@@ -1374,8 +1398,8 @@ mod tests {
             key_values[FIELD_EXCEPTION_STACKTRACE],
             Value::Array(
                 vec![
-                    Cow::Borrowed("intermediate error"),
-                    Cow::Borrowed("base error")
+                    StringValue::from("intermediate error"),
+                    StringValue::from("base error")
                 ]
                 .into()
             )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,7 +9,7 @@
 //! [OpenTelemetry]: https://opentelemetry.io
 //! [`tracing`]: https://github.com/tokio-rs/tracing
 //!
-//! *Compiler support: [requires `rustc` 1.49+][msrv]*
+//! *Compiler support: [requires `rustc` 1.56+][msrv]*
 //!
 //! [msrv]: #supported-rust-versions
 //!
@@ -86,7 +86,7 @@
 //! ## Supported Rust Versions
 //!
 //! Tracing is built against the latest stable release. The minimum supported
-//! version is 1.49. The current Tracing version is not guaranteed to build on
+//! version is 1.56. The current Tracing version is not guaranteed to build on
 //! Rust versions earlier than the minimum supported version.
 //!
 //! Tracing follows the same compiler support policies as the rest of the Tokio

--- a/tests/metrics_publishing.rs
+++ b/tests/metrics_publishing.rs
@@ -1,26 +1,21 @@
-#![cfg(feature = "metrics")]
-use async_trait::async_trait;
-use futures_util::{Stream, StreamExt as _};
 use opentelemetry::{
-    metrics::{Descriptor, InstrumentKind},
-    metrics::{Number, NumberKind},
+    metrics::MetricsError,
     sdk::{
-        export::{
-            metrics::{
-                CheckpointSet, ExportKind, ExportKindFor, ExportKindSelector,
-                Exporter as MetricsExporter, Points, Sum,
-            },
-            trace::{SpanData, SpanExporter},
+        export::metrics::{
+            aggregation::{self, Histogram, Sum, TemporalitySelector},
+            InstrumentationLibraryReader,
         },
         metrics::{
-            aggregators::{ArrayAggregator, SumAggregator},
-            selectors::simple::Selector,
+            aggregators::{HistogramAggregator, SumAggregator},
+            controllers::BasicController,
+            processors,
+            sdk_api::{Descriptor, InstrumentKind, Number, NumberKind},
+            selectors,
         },
     },
-    Key, Value,
+    Context,
 };
 use std::cmp::Ordering;
-use std::time::Duration;
 use tracing::Subscriber;
 use tracing_opentelemetry::MetricsLayer;
 use tracing_subscriber::prelude::*;
@@ -30,7 +25,7 @@ const INSTRUMENTATION_LIBRARY_NAME: &str = "tracing/tracing-opentelemetry";
 
 #[tokio::test]
 async fn u64_counter_is_exported() {
-    let subscriber = init_subscriber(
+    let (subscriber, exporter) = init_subscriber(
         "hello_world".to_string(),
         InstrumentKind::Counter,
         NumberKind::U64,
@@ -40,11 +35,13 @@ async fn u64_counter_is_exported() {
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(monotonic_counter.hello_world = 1_u64);
     });
+
+    exporter.export().unwrap();
 }
 
 #[tokio::test]
 async fn u64_counter_is_exported_i64_at_instrumentation_point() {
-    let subscriber = init_subscriber(
+    let (subscriber, exporter) = init_subscriber(
         "hello_world2".to_string(),
         InstrumentKind::Counter,
         NumberKind::U64,
@@ -54,11 +51,13 @@ async fn u64_counter_is_exported_i64_at_instrumentation_point() {
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(monotonic_counter.hello_world2 = 1_i64);
     });
+
+    exporter.export().unwrap();
 }
 
 #[tokio::test]
 async fn f64_counter_is_exported() {
-    let subscriber = init_subscriber(
+    let (subscriber, exporter) = init_subscriber(
         "float_hello_world".to_string(),
         InstrumentKind::Counter,
         NumberKind::F64,
@@ -68,11 +67,13 @@ async fn f64_counter_is_exported() {
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(monotonic_counter.float_hello_world = 1.000000123_f64);
     });
+
+    exporter.export().unwrap();
 }
 
 #[tokio::test]
 async fn i64_up_down_counter_is_exported() {
-    let subscriber = init_subscriber(
+    let (subscriber, exporter) = init_subscriber(
         "pebcak".to_string(),
         InstrumentKind::UpDownCounter,
         NumberKind::I64,
@@ -82,11 +83,13 @@ async fn i64_up_down_counter_is_exported() {
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(counter.pebcak = -5_i64);
     });
+
+    exporter.export().unwrap();
 }
 
 #[tokio::test]
 async fn i64_up_down_counter_is_exported_u64_at_instrumentation_point() {
-    let subscriber = init_subscriber(
+    let (subscriber, exporter) = init_subscriber(
         "pebcak2".to_string(),
         InstrumentKind::UpDownCounter,
         NumberKind::I64,
@@ -96,11 +99,13 @@ async fn i64_up_down_counter_is_exported_u64_at_instrumentation_point() {
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(counter.pebcak2 = 5_u64);
     });
+
+    exporter.export().unwrap();
 }
 
 #[tokio::test]
 async fn f64_up_down_counter_is_exported() {
-    let subscriber = init_subscriber(
+    let (subscriber, exporter) = init_subscriber(
         "pebcak_blah".to_string(),
         InstrumentKind::UpDownCounter,
         NumberKind::F64,
@@ -110,13 +115,15 @@ async fn f64_up_down_counter_is_exported() {
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(counter.pebcak_blah = 99.123_f64);
     });
+
+    exporter.export().unwrap();
 }
 
 #[tokio::test]
-async fn u64_value_is_exported() {
-    let subscriber = init_subscriber(
+async fn u64_histogram_is_exported() {
+    let (subscriber, exporter) = init_subscriber(
         "abcdefg".to_string(),
-        InstrumentKind::ValueRecorder,
+        InstrumentKind::Histogram,
         NumberKind::U64,
         Number::from(9_u64),
     );
@@ -124,13 +131,15 @@ async fn u64_value_is_exported() {
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(value.abcdefg = 9_u64);
     });
+
+    exporter.export().unwrap();
 }
 
 #[tokio::test]
-async fn i64_value_is_exported() {
-    let subscriber = init_subscriber(
+async fn i64_histogram_is_exported() {
+    let (subscriber, exporter) = init_subscriber(
         "abcdefg_auenatsou".to_string(),
-        InstrumentKind::ValueRecorder,
+        InstrumentKind::Histogram,
         NumberKind::I64,
         Number::from(-19_i64),
     );
@@ -138,13 +147,15 @@ async fn i64_value_is_exported() {
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(value.abcdefg_auenatsou = -19_i64);
     });
+
+    exporter.export().unwrap();
 }
 
 #[tokio::test]
-async fn f64_value_is_exported() {
-    let subscriber = init_subscriber(
+async fn f64_histogram_is_exported() {
+    let (subscriber, exporter) = init_subscriber(
         "abcdefg_racecar".to_string(),
-        InstrumentKind::ValueRecorder,
+        InstrumentKind::Histogram,
         NumberKind::F64,
         Number::from(777.0012_f64),
     );
@@ -152,6 +163,8 @@ async fn f64_value_is_exported() {
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(value.abcdefg_racecar = 777.0012_f64);
     });
+
+    exporter.export().unwrap();
 }
 
 fn init_subscriber(
@@ -159,24 +172,24 @@ fn init_subscriber(
     expected_instrument_kind: InstrumentKind,
     expected_number_kind: NumberKind,
     expected_value: Number,
-) -> impl Subscriber + 'static {
+) -> (impl Subscriber + 'static, TestExporter) {
+    let controller = opentelemetry::sdk::metrics::controllers::basic(processors::factory(
+        selectors::simple::histogram(vec![-10.0, 100.0]),
+        aggregation::cumulative_temporality_selector(),
+    ))
+    .build();
     let exporter = TestExporter {
         expected_metric_name,
         expected_instrument_kind,
         expected_number_kind,
         expected_value,
+        controller: controller.clone(),
     };
 
-    let push_controller = opentelemetry::sdk::metrics::controllers::push(
-        Selector::Exact,
-        ExportKindSelector::Stateless,
+    (
+        tracing_subscriber::registry().with(MetricsLayer::new(controller)),
         exporter,
-        tokio::spawn,
-        delayed_interval,
     )
-    .build();
-
-    tracing_subscriber::registry().with(MetricsLayer::new(push_controller))
 }
 
 #[derive(Clone, Debug)]
@@ -185,100 +198,84 @@ struct TestExporter {
     expected_instrument_kind: InstrumentKind,
     expected_number_kind: NumberKind,
     expected_value: Number,
+    controller: BasicController,
 }
 
-#[async_trait]
-impl SpanExporter for TestExporter {
-    async fn export(
-        &mut self,
-        mut _batch: Vec<SpanData>,
-    ) -> opentelemetry::sdk::export::trace::ExportResult {
-        Ok(())
-    }
-}
+impl TestExporter {
+    fn export(&self) -> Result<(), MetricsError> {
+        self.controller.collect(&Context::current())?;
+        self.controller.try_for_each(&mut |library, reader| {
+            reader.try_for_each(self, &mut |record| {
+                assert_eq!(self.expected_metric_name, record.descriptor().name());
+                assert_eq!(
+                    self.expected_instrument_kind,
+                    *record.descriptor().instrument_kind()
+                );
+                assert_eq!(
+                    self.expected_number_kind,
+                    *record.descriptor().number_kind()
+                );
+                match self.expected_instrument_kind {
+                    InstrumentKind::Counter | InstrumentKind::UpDownCounter => {
+                        let number = record
+                            .aggregator()
+                            .unwrap()
+                            .as_any()
+                            .downcast_ref::<SumAggregator>()
+                            .unwrap()
+                            .sum()
+                            .unwrap();
 
-impl MetricsExporter for TestExporter {
-    fn export(&self, checkpoint_set: &mut dyn CheckpointSet) -> opentelemetry::metrics::Result<()> {
-        checkpoint_set.try_for_each(self, &mut |record| {
-            assert_eq!(self.expected_metric_name, record.descriptor().name());
-            assert_eq!(
-                self.expected_instrument_kind,
-                *record.descriptor().instrument_kind()
-            );
-            assert_eq!(
-                self.expected_number_kind,
-                *record.descriptor().number_kind()
-            );
-            let number = match self.expected_instrument_kind {
-                InstrumentKind::Counter | InstrumentKind::UpDownCounter => record
-                    .aggregator()
-                    .unwrap()
-                    .as_any()
-                    .downcast_ref::<SumAggregator>()
-                    .unwrap()
-                    .sum()
-                    .unwrap(),
-                InstrumentKind::ValueRecorder => record
-                    .aggregator()
-                    .unwrap()
-                    .as_any()
-                    .downcast_ref::<ArrayAggregator>()
-                    .unwrap()
-                    .points()
-                    .unwrap()[0]
-                    .clone(),
-                _ => panic!(
-                    "InstrumentKind {:?} not currently supported!",
-                    self.expected_instrument_kind
-                ),
-            };
-            assert_eq!(
-                Ordering::Equal,
-                number
-                    .partial_cmp(&NumberKind::U64, &self.expected_value)
-                    .unwrap()
-            );
+                        assert_eq!(
+                            Ordering::Equal,
+                            number
+                                .partial_cmp(&NumberKind::U64, &self.expected_value)
+                                .unwrap()
+                        );
+                    }
+                    InstrumentKind::Histogram => {
+                        let histogram = record
+                            .aggregator()
+                            .unwrap()
+                            .as_any()
+                            .downcast_ref::<HistogramAggregator>()
+                            .unwrap()
+                            .histogram()
+                            .unwrap();
 
-            // The following are the same regardless of the individual metric.
-            assert_eq!(
-                INSTRUMENTATION_LIBRARY_NAME,
-                record.descriptor().instrumentation_library().name
-            );
-            assert_eq!(
-                CARGO_PKG_VERSION,
-                record.descriptor().instrumentation_version().unwrap()
-            );
-            assert_eq!(
-                Value::String("unknown_service".into()),
-                record
-                    .resource()
-                    .get(Key::new("service.name".to_string()))
-                    .unwrap()
-            );
+                        let counts = histogram.counts();
+                        if dbg!(self.expected_value.to_i64(&self.expected_number_kind)) > 100 {
+                            assert_eq!(counts, &[0.0, 0.0, 1.0]);
+                        } else if self.expected_value.to_i64(&self.expected_number_kind) > 0 {
+                            assert_eq!(counts, &[0.0, 1.0, 0.0]);
+                        } else {
+                            assert_eq!(counts, &[1.0, 0.0, 0.0]);
+                        }
+                    }
+                    _ => panic!(
+                        "InstrumentKind {:?} not currently supported!",
+                        self.expected_instrument_kind
+                    ),
+                };
 
-            opentelemetry::metrics::Result::Ok(())
+                // The following are the same regardless of the individual metric.
+                assert_eq!(INSTRUMENTATION_LIBRARY_NAME, library.name);
+                assert_eq!(CARGO_PKG_VERSION, library.version.as_ref().unwrap());
+
+                Ok(())
+            })
         })
     }
 }
 
-impl ExportKindFor for TestExporter {
-    fn export_kind_for(&self, _descriptor: &Descriptor) -> ExportKind {
+impl TemporalitySelector for TestExporter {
+    fn temporality_for(
+        &self,
+        _descriptor: &Descriptor,
+        _kind: &aggregation::AggregationKind,
+    ) -> aggregation::Temporality {
         // I don't think the value here makes a difference since
         // we are just testing a single metric.
-        ExportKind::Cumulative
+        aggregation::Temporality::Cumulative
     }
-}
-
-// From opentelemetry::sdk::util::
-// For some reason I can't pull it in from the other crate, it gives
-//   could not find `util` in `sdk`
-/// Helper which wraps `tokio::time::interval` and makes it return a stream
-fn tokio_interval_stream(period: std::time::Duration) -> tokio_stream::wrappers::IntervalStream {
-    tokio_stream::wrappers::IntervalStream::new(tokio::time::interval(period))
-}
-
-// https://github.com/open-telemetry/opentelemetry-rust/blob/2585d109bf90d53d57c91e19c758dca8c36f5512/examples/basic-otlp/src/main.rs#L34-L37
-// Skip first immediate tick from tokio, not needed for async_std.
-fn delayed_interval(duration: Duration) -> impl Stream<Item = tokio::time::Instant> {
-    tokio_interval_stream(duration).skip(0)
 }


### PR DESCRIPTION
## Motivation
I noticed that this repo got the cut-off before opentelemetry 0.18 was committed into the main repo so I tried to backport what was there.

## Solution
This is pretty much a backport from the code that @jtescher did on the main repo.

Let me know if you see something wrong, I tried to adapt the rejections the best way possible.

This fix #8 