### PR TITLE
chore: migrate examples from the main tracing repo over

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,8 @@ thiserror = { version = "1.0.31", optional = true }
 async-trait = "0.1.56"
 criterion = { version = "0.3.6", default-features = false }
 opentelemetry-jaeger = "0.16.0"
+tracing = { version = "0.1.35", default-features = false, features = ["std", "attributes"] }
+tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
 futures-util = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/examples/opentelemetry-remote-context.rs
+++ b/examples/opentelemetry-remote-context.rs
@@ -1,0 +1,46 @@
+use opentelemetry::sdk::propagation::TraceContextPropagator;
+use opentelemetry::{global, Context};
+use std::collections::HashMap;
+use tracing::span;
+use tracing_opentelemetry::OpenTelemetrySpanExt;
+use tracing_subscriber::layer::SubscriberExt;
+use tracing_subscriber::Registry;
+
+fn make_request(_cx: Context) {
+    // perform external request after injecting context
+    // e.g. if there are request headers that impl `opentelemetry::propagation::Injector`
+    // then `propagator.inject_context(cx, request.headers_mut())`
+}
+
+fn build_example_carrier() -> HashMap<String, String> {
+    let mut carrier = HashMap::new();
+    carrier.insert(
+        "traceparent".to_string(),
+        "00-0af7651916cd43dd8448eb211c80319c-b7ad6b7169203331-01".to_string(),
+    );
+
+    carrier
+}
+
+fn main() {
+    // Set a format for propagating context. This MUST be provided, as the default is a no-op.
+    global::set_text_map_propagator(TraceContextPropagator::new());
+    let subscriber = Registry::default().with(tracing_opentelemetry::layer());
+
+    tracing::subscriber::with_default(subscriber, || {
+        // Extract context from request headers
+        let parent_context = global::get_text_map_propagator(|propagator| {
+            propagator.extract(&build_example_carrier())
+        });
+
+        // Generate tracing span as usual
+        let app_root = span!(tracing::Level::INFO, "app_start");
+
+        // Assign parent trace from external context
+        app_root.set_parent(parent_context);
+
+        // To include tracing context in client requests from _this_ app,
+        // use `context` to extract the current OpenTelemetry context.
+        make_request(app_root.context());
+    });
+}

--- a/examples/opentelemetry.rs
+++ b/examples/opentelemetry.rs
@@ -1,0 +1,48 @@
+use opentelemetry::global;
+use std::{error::Error, thread, time::Duration};
+use tracing::{instrument, span, trace, warn};
+use tracing_subscriber::prelude::*;
+
+#[instrument]
+#[inline]
+fn expensive_work() -> &'static str {
+    span!(tracing::Level::INFO, "expensive_step_1")
+        .in_scope(|| thread::sleep(Duration::from_millis(25)));
+    span!(tracing::Level::INFO, "expensive_step_2")
+        .in_scope(|| thread::sleep(Duration::from_millis(25)));
+
+    "success"
+}
+
+fn main() -> Result<(), Box<dyn Error + Send + Sync + 'static>> {
+    // Install an otel pipeline with a simple span processor that exports data one at a time when
+    // spans end. See the `install_batch` option on each exporter's pipeline builder to see how to
+    // export in batches.
+    let tracer = opentelemetry_jaeger::new_pipeline()
+        .with_service_name("report_example")
+        .install_simple()?;
+    let opentelemetry = tracing_opentelemetry::layer().with_tracer(tracer);
+    tracing_subscriber::registry()
+        .with(opentelemetry)
+        .try_init()?;
+
+    {
+        let root = span!(tracing::Level::INFO, "app_start", work_units = 2);
+        let _enter = root.enter();
+
+        let work_result = expensive_work();
+
+        span!(tracing::Level::INFO, "faster_work")
+            .in_scope(|| thread::sleep(Duration::from_millis(10)));
+
+        warn!("About to exit!");
+        trace!("status: {}", work_result);
+    } // Once this scope is closed, all spans inside are closed as well
+
+    // Shut down the current tracer provider. This will invoke the shutdown
+    // method on all span processors. span processors should export remaining
+    // spans before return.
+    global::shutdown_tracer_provider();
+
+    Ok(())
+}


### PR DESCRIPTION
As part of moving tracing-opentelemetry over, I'm moving the tracing-opentelemetry examples over from `tokio-rs/tracing` to here.