### PR TITLE
Update the repository URL in Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,7 +7,7 @@ authors = [
 ]
 description = "OpenTelemetry integration for tracing"
 homepage = "https://github.com/tokio-rs/tracing/tree/master/tracing-opentelemetry"
-repository = "https://github.com/tokio-rs/tracing"
+repository = "https://github.com/tokio-rs/tracing-opentelemetry"
 readme = "README.md"
 categories = [
     "development-tools::debugging",


### PR DESCRIPTION
Changes the URL for the repository in Cargo.toml

## Motivation

Clicking "repository" in crates.io leads to the old parent repository

## Solution

Change the URL