### PR TITLE
Update homepage and repository links

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,8 +6,8 @@ authors = [
     "Tokio Contributors <team@tokio.rs>"
 ]
 description = "OpenTelemetry integration for tracing"
-homepage = "https://github.com/tokio-rs/tracing/tree/master/tracing-opentelemetry"
-repository = "https://github.com/tokio-rs/tracing"
+homepage = "https://github.com/tokio-rs/tracing-opentelemetry"
+repository = "https://github.com/tokio-rs/tracing-opentelemetry"
 readme = "README.md"
 categories = [
     "development-tools::debugging",


### PR DESCRIPTION
Because opentelemetry tracer was moved to own repository, homepage and repository parameters of Cargo.toml should represent the change.
