### PR TITLE
Prepare for v0.19.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,12 @@
+# 0.19.0 (May 23, 2023)
+
+### Breaking Changes
+
+- Upgrade to `v0.19.0` of `opentelemetry` (#12)
+  For list of breaking changes in OpenTelemetry, see the
+  [v0.19.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#v0190).
+- Update MSRV to require rust v1.60+ as `opentelemetry` requires it now (#12)
+
 # 0.18.0 (September 18, 2022)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@
   [v0.19.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#v0190).
 - Update MSRV to require Rust 1.60+, as `opentelemetry` requires it now (#12)
 
+Thanks to @jaysonsantos, @briankung, and @humb1t for contributing to this release!
+
 # 0.18.0 (September 18, 2022)
 
 ### Breaking Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 - Upgrade to `v0.19.0` of `opentelemetry` (#12)
   For list of breaking changes in OpenTelemetry, see the
   [v0.19.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#v0190).
-- Update MSRV to require rust v1.60+ as `opentelemetry` requires it now (#12)
+- Update MSRV to require Rust 1.60+, as `opentelemetry` requires it now (#12)
 
 # 0.18.0 (September 18, 2022)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.18.0"
+version = "0.19.0"
 authors = [
     "Julian Tescher <julian@tescher.me>",
     "Tokio Contributors <team@tokio.rs>"

--- a/README.md
+++ b/README.md
@@ -17,15 +17,15 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-opentelemetry.svg
-[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.18.0
+[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.19.0
 [docs-badge]: https://docs.rs/tracing-opentelemetry/badge.svg
-[docs-url]: https://docs.rs/tracing-opentelemetry/0.18.0/tracing_opentelemetry
+[docs-url]: https://docs.rs/tracing-opentelemetry/0.19.0/tracing_opentelemetry
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_opentelemetry
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
 [mit-url]: LICENSE
-[actions-badge]: https://github.com/tokio-rs/tracing/workflows/CI/badge.svg
-[actions-url]:https://github.com/tokio-rs/tracing/actions?query=workflow%3ACI
+[actions-badge]: https://github.com/tokio-rs/tracing-opentelemetry/workflows/CI/badge.svg
+[actions-url]:https://github.com/tokio-rs/tracing-opentelemetry/actions?query=workflow%3ACI
 [discord-badge]: https://img.shields.io/discord/500028886025895936?logo=discord&label=discord&logoColor=white
 [discord-url]: https://discord.gg/EeF3cQw
 [maint-badge]: https://img.shields.io/badge/maintenance-actively--developed-brightgreen.svg

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -100,10 +100,10 @@
 //! [subscriber]: tracing_subscriber::subscribe
 #![deny(unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.18.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.19.0")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
-    issue_tracker_base_url = "https://github.com/tokio-rs/tracing/issues/"
+    issue_tracker_base_url = "https://github.com/tokio-rs/tracing-opentelemetry/issues/"
 )]
 #![cfg_attr(
     docsrs,


### PR DESCRIPTION
Changelog:

### Breaking Changes

- Upgrade to `v0.19.0` of `opentelemetry` (#12)
  For list of breaking changes in OpenTelemetry, see the [v0.19.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry/CHANGELOG.md#v0190).
- Update MSRV to require rust v1.60+, as `opentelemetry` requires it now (#12)

Thanks to @jaysonsantos, @briankung, and @humb1t for contributing to this release!
