### PR TITLE
Set builder parent span to None when manually setting parent

### DIFF
--- a/src/span_ext.rs
+++ b/src/span_ext.rs
@@ -124,6 +124,7 @@ impl OpenTelemetrySpanExt for tracing::Span {
                 get_context.with_context(subscriber, id, move |data, _tracer| {
                     if let Some(cx) = cx.take() {
                         data.parent_cx = cx;
+                        data.builder.trace_id = None;
                     }
                 });
             }


### PR DESCRIPTION
Closes #25

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing-opentelemetry/blob/master/CONTRIBUTING.md
-->

## Motivation

When I tried to find a parent span as someone not familiar with the code I tried using what's in the builder and if there's None I tried the parent context (which always has trace ID, it just might be invalid).

This change should simplify this for people unfamiliar with the codebase by getting rid of the trace ID that's not used.
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Set trace ID in builder to `None`. It has not been used anywhere if parent_cx contained a valid trace ID so no other changes are needed.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
