### PR TITLE
Enable flame graphs and reports for benchmarks

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,8 +38,9 @@ thiserror = { version = "1.0.31", optional = true }
 
 [dev-dependencies]
 async-trait = "0.1.56"
-criterion = { version = "0.5.0", default-features = false }
+criterion = { version = "0.4.0", default-features = false, features = ["html_reports"] }
 opentelemetry-jaeger = "0.18.0"
+pprof = { version = "0.11.1", features = ["flamegraph", "criterion"] }
 futures-util = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/benches/trace.rs
+++ b/benches/trace.rs
@@ -4,6 +4,7 @@ use opentelemetry::{
     trace::{SpanBuilder, Tracer as _, TracerProvider as _},
     Context,
 };
+use pprof::criterion::{Output, PProfProfiler};
 use std::time::SystemTime;
 use tracing::trace_span;
 use tracing_subscriber::prelude::*;
@@ -122,5 +123,9 @@ fn tracing_harness() {
     dummy();
 }
 
-criterion_group!(benches, many_children);
+criterion_group! {
+    name = benches;
+    config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = many_children
+}
 criterion_main!(benches);


### PR DESCRIPTION
In order to more easily interpret benchmark data, I enabled criterion HTML reports and flame graphs.
