### PR TITLE
chore: use pprof only if target_os is not windows

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,11 +41,13 @@ async-trait = "0.1.56"
 criterion = { version = "0.4.0", default-features = false, features = ["html_reports"] }
 opentelemetry-jaeger = "0.19.0"
 opentelemetry-stdout = { version = "0.1.0", features = ["trace"] }
-pprof = { version = "0.11.1", features = ["flamegraph", "criterion"] }
 futures-util = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 tracing = { version = "0.1.35", default-features = false, features = ["std", "attributes"] }
+
+[target.'cfg(not(target_os = "windows"))'.dev-dependencies]
+pprof = { version = "0.11.1", features = ["flamegraph", "criterion"] }
 
 [lib]
 bench = false

--- a/benches/trace.rs
+++ b/benches/trace.rs
@@ -4,6 +4,7 @@ use opentelemetry::{
     trace::{SpanBuilder, Tracer as _, TracerProvider as _},
     Context,
 };
+#[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};
 use std::time::SystemTime;
 use tracing::trace_span;
@@ -123,9 +124,16 @@ fn tracing_harness() {
     dummy();
 }
 
+#[cfg(not(target_os = "windows"))]
 criterion_group! {
     name = benches;
     config = Criterion::default().with_profiler(PProfProfiler::new(100, Output::Flamegraph(None)));
+    targets = many_children
+}
+#[cfg(target_os = "windows")]
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
     targets = many_children
 }
 criterion_main!(benches);


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing-opentelemetry/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Fix https://github.com/tokio-rs/tracing-opentelemetry/issues/39


## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

add `#[cfg(not(target_os = "windows"))]` condition to pprof dependencies