### PR TITLE
Prepare for v0.20.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,17 @@
+# 0.20.0 (August 1, 2023)
+
+### Added
+
+- Add `OpenTelemetrySpanExt::set_attribute` function (#34)
+
+### Breaking Changes
+
+- Upgrade to `v0.20.0` of `opentelemetry` (#36)
+  For list of breaking changes in OpenTelemetry, see the
+  [v0.20.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/v0.20.0/opentelemetry-api/CHANGELOG.md#v0200).
+
+Thanks to @ymgyt, @mladedav, @shaun-cox, and @Protryon for contributing to this release!
+
 # 0.19.0 (May 23, 2023)
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.19.0"
+version = "0.20.0"
 authors = [
     "Julian Tescher <julian@tescher.me>",
     "Tokio Contributors <team@tokio.rs>"


### PR DESCRIPTION
Changelog:

### Added

- Add `OpenTelemetrySpanExt::set_attribute` function (#34)

### Breaking Changes

- Upgrade to `v0.20.0` of `opentelemetry` (#36)
  For list of breaking changes in OpenTelemetry, see the
  [v0.20.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/v0.20.0/opentelemetry-api/CHANGELOG.md#v0200).