### PR TITLE
feat: produce measurement with attributes

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,6 +35,7 @@ once_cell = "1.13.0"
 # Fix minimal-versions
 async-trait = { version = "0.1.56", optional = true }
 thiserror = { version = "1.0.31", optional = true }
+smallvec = "1.11.0"
 
 [dev-dependencies]
 async-trait = "0.1.56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,7 @@ once_cell = "1.13.0"
 # Fix minimal-versions
 async-trait = { version = "0.1.56", optional = true }
 thiserror = { version = "1.0.31", optional = true }
-smallvec = "1.11.0"
+smallvec = "1.0"
 
 [dev-dependencies]
 async-trait = "0.1.56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ rust-version = "1.60.0"
 [features]
 default = ["tracing-log", "metrics"]
 # Enables support for exporting OpenTelemetry metrics
-metrics = ["opentelemetry/metrics"]
+metrics = ["opentelemetry/metrics", "smallvec"]
 
 [dependencies]
 opentelemetry = { version = "0.20.0", default-features = false, features = ["trace"] }
@@ -35,7 +35,7 @@ once_cell = "1.13.0"
 # Fix minimal-versions
 async-trait = { version = "0.1.56", optional = true }
 thiserror = { version = "1.0.31", optional = true }
-smallvec = "1.0"
+smallvec = { version = "1.0", optional = true }
 
 [dev-dependencies]
 async-trait = "0.1.56"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,6 +57,10 @@ bench = false
 name = "trace"
 harness = false
 
+[[bench]]
+name = "metrics"
+harness = false
+
 [package.metadata.docs.rs]
 all-features = true
 rustdoc-args = ["--cfg", "docsrs"]

--- a/benches/metrics.rs
+++ b/benches/metrics.rs
@@ -1,0 +1,114 @@
+use criterion::{criterion_group, criterion_main, Criterion};
+use opentelemetry::metrics::noop::NoopMeterProvider;
+use tracing_opentelemetry::MetricsLayer;
+use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+fn metrics_events(c: &mut Criterion) {
+    let mut group = c.benchmark_group("otel_metrics_events");
+    {
+        let _subscriber = tracing_subscriber::registry().set_default();
+        group.bench_function("no_metrics_layer", |b| {
+            b.iter(|| {
+                tracing::info!(key_1 = "va", "msg");
+            })
+        });
+    }
+
+    {
+        let _subscriber = tracing_subscriber::registry()
+            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .set_default();
+        group.bench_function("no_metrics_events", |b| {
+            b.iter(|| {
+                tracing::info!(key_1 = "va", "msg");
+            })
+        });
+    }
+
+    {
+        let _subscriber = tracing_subscriber::registry()
+            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .set_default();
+        group.bench_function("1_metrics_event", |b| {
+            b.iter(|| {
+                tracing::info!(monotonic_counter.foo = 1, "msg");
+            })
+        });
+    }
+
+    {
+        let _subscriber = tracing_subscriber::registry()
+            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .set_default();
+        group.bench_function("2_metrics_events", |b| {
+            b.iter(|| {
+                tracing::info!(monotonic_counter.foo = 1, monotonic_counter.bar = 1, "msg");
+            })
+        });
+    }
+
+    {
+        let _subscriber = tracing_subscriber::registry()
+            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .set_default();
+        group.bench_function("1_metrics_event_with_attributes", |b| {
+            b.iter(|| {
+                tracing::info!(monotonic_counter.foo = 1, attr_1 = 10, "msg");
+            })
+        });
+    }
+
+    {
+        let _subscriber = tracing_subscriber::registry()
+            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .set_default();
+        group.bench_function("1_metrics_event_with_attributes_8", |b| {
+            b.iter(|| {
+                tracing::info!(
+                    monotonic_counter.foo = 1,
+                    attr_1 = 10,
+                    attr_2 = 20,
+                    attr_3 = 30,
+                    attr_4 = 40,
+                    attr_5 = 50,
+                    attr_6 = 60,
+                    attr_7 = 70,
+                    attr_8 = 80,
+                    "msg"
+                );
+            })
+        });
+    }
+
+    {
+        let _subscriber = tracing_subscriber::registry()
+            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .set_default();
+        group.bench_function("no_metrics_event_with_attributes_12", |b| {
+            b.iter(|| {
+                tracing::info!(
+                    attr_1 = 10,
+                    attr_2 = 20,
+                    attr_3 = 30,
+                    attr_4 = 40,
+                    attr_5 = 50,
+                    attr_6 = 60,
+                    attr_7 = 70,
+                    attr_8 = 80,
+                    attr_9 = 90,
+                    attr_10 = 100,
+                    attr_11 = 110,
+                    attr_12 = 120,
+                    "msg"
+                );
+            })
+        });
+    }
+}
+
+criterion_group! {
+    name = benches;
+    config = Criterion::default();
+    targets = metrics_events
+}
+criterion_main!(benches);

--- a/benches/metrics.rs
+++ b/benches/metrics.rs
@@ -18,7 +18,7 @@ fn metrics_events(c: &mut Criterion) {
         let _subscriber = tracing_subscriber::registry()
             .with(MetricsLayer::new(NoopMeterProvider::new()))
             .set_default();
-        group.bench_function("no_metrics_events", |b| {
+        group.bench_function("metrics_events_0_attr_0", |b| {
             b.iter(|| {
                 tracing::info!(key_1 = "va", "msg");
             })
@@ -29,9 +29,9 @@ fn metrics_events(c: &mut Criterion) {
         let _subscriber = tracing_subscriber::registry()
             .with(MetricsLayer::new(NoopMeterProvider::new()))
             .set_default();
-        group.bench_function("1_metrics_event", |b| {
+        group.bench_function("metrics_events_1_attr_0", |b| {
             b.iter(|| {
-                tracing::info!(monotonic_counter.foo = 1, "msg");
+                tracing::info!(monotonic_counter.c1 = 1, "msg");
             })
         });
     }
@@ -40,9 +40,9 @@ fn metrics_events(c: &mut Criterion) {
         let _subscriber = tracing_subscriber::registry()
             .with(MetricsLayer::new(NoopMeterProvider::new()))
             .set_default();
-        group.bench_function("2_metrics_events", |b| {
+        group.bench_function("metrics_events_2_attr_0", |b| {
             b.iter(|| {
-                tracing::info!(monotonic_counter.foo = 1, monotonic_counter.bar = 1, "msg");
+                tracing::info!(monotonic_counter.c1 = 1, monotonic_counter.c2 = 1, "msg");
             })
         });
     }
@@ -51,29 +51,13 @@ fn metrics_events(c: &mut Criterion) {
         let _subscriber = tracing_subscriber::registry()
             .with(MetricsLayer::new(NoopMeterProvider::new()))
             .set_default();
-        group.bench_function("1_metrics_event_with_attributes", |b| {
-            b.iter(|| {
-                tracing::info!(monotonic_counter.foo = 1, attr_1 = 10, "msg");
-            })
-        });
-    }
-
-    {
-        let _subscriber = tracing_subscriber::registry()
-            .with(MetricsLayer::new(NoopMeterProvider::new()))
-            .set_default();
-        group.bench_function("1_metrics_event_with_attributes_8", |b| {
+        group.bench_function("metrics_events_4_attr_0", |b| {
             b.iter(|| {
                 tracing::info!(
-                    monotonic_counter.foo = 1,
-                    attr_1 = 10,
-                    attr_2 = 20,
-                    attr_3 = 30,
-                    attr_4 = 40,
-                    attr_5 = 50,
-                    attr_6 = 60,
-                    attr_7 = 70,
-                    attr_8 = 80,
+                    monotonic_counter.c1 = 1,
+                    monotonic_counter.c2 = 1,
+                    monotonic_counter.c3 = 1,
+                    monotonic_counter.c4 = 1,
                     "msg"
                 );
             })
@@ -84,26 +68,90 @@ fn metrics_events(c: &mut Criterion) {
         let _subscriber = tracing_subscriber::registry()
             .with(MetricsLayer::new(NoopMeterProvider::new()))
             .set_default();
-        group.bench_function("no_metrics_event_with_attributes_12", |b| {
+        group.bench_function("metrics_events_8_attr_0", |b| {
             b.iter(|| {
                 tracing::info!(
-                    attr_1 = 10,
-                    attr_2 = 20,
-                    attr_3 = 30,
-                    attr_4 = 40,
-                    attr_5 = 50,
-                    attr_6 = 60,
-                    attr_7 = 70,
-                    attr_8 = 80,
-                    attr_9 = 90,
-                    attr_10 = 100,
-                    attr_11 = 110,
-                    attr_12 = 120,
+                    monotonic_counter.c1 = 1,
+                    monotonic_counter.c2 = 1,
+                    monotonic_counter.c3 = 1,
+                    monotonic_counter.c4 = 1,
+                    monotonic_counter.c5 = 1,
+                    monotonic_counter.c6 = 1,
+                    monotonic_counter.c7 = 1,
+                    monotonic_counter.c8 = 1,
                     "msg"
                 );
             })
         });
     }
+
+    {
+        let _subscriber = tracing_subscriber::registry()
+            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .set_default();
+        group.bench_function("metrics_events_1_attr_1", |b| {
+            b.iter(|| {
+                tracing::info!(monotonic_counter.c1 = 1, key_1 = 1_i64, "msg");
+            })
+        });
+    }
+
+    {
+        let _subscriber = tracing_subscriber::registry()
+            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .set_default();
+        group.bench_function("metrics_events_1_attr_2", |b| {
+            b.iter(|| {
+                tracing::info!(
+                    monotonic_counter.c1 = 1,
+                    key_1 = 1_i64,
+                    key_2 = 1_i64,
+                    "msg"
+                );
+            })
+        });
+    }
+
+    {
+        let _subscriber = tracing_subscriber::registry()
+            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .set_default();
+        group.bench_function("metrics_events_1_attr_4", |b| {
+            b.iter(|| {
+                tracing::info!(
+                    monotonic_counter.c1 = 1,
+                    key_1 = 1_i64,
+                    key_2 = 1_i64,
+                    key_3 = 1_i64,
+                    key_4 = 1_i64,
+                    "msg"
+                );
+            })
+        });
+    }
+
+    {
+        let _subscriber = tracing_subscriber::registry()
+            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .set_default();
+        group.bench_function("metrics_events_1_attr_8", |b| {
+            b.iter(|| {
+                tracing::info!(
+                    monotonic_counter.c1 = 1,
+                    key_1 = 1_i64,
+                    key_2 = 1_i64,
+                    key_3 = 1_i64,
+                    key_4 = 1_i64,
+                    key_5 = 1_i64,
+                    key_6 = 1_i64,
+                    key_7 = 1_i64,
+                    key_8 = 1_i64,
+                    "msg"
+                );
+            })
+        });
+    }
+    group.finish();
 }
 
 criterion_group! {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -354,7 +354,7 @@ where
 struct MetricsFilter;
 
 impl MetricsFilter {
-    fn has_metrics_fields(&self, meta: &Metadata<'_>) -> bool {
+    fn is_metrics_event(&self, meta: &Metadata<'_>) -> bool {
         meta.is_event()
             && meta.fields().iter().any(|field| {
                 let name = field.name();
@@ -367,11 +367,11 @@ impl MetricsFilter {
 
 impl<S> Filter<S> for MetricsFilter {
     fn enabled(&self, meta: &Metadata<'_>, _cx: &Context<'_, S>) -> bool {
-        self.has_metrics_fields(meta)
+        self.is_metrics_event(meta)
     }
 
     fn callsite_enabled(&self, meta: &'static Metadata<'static>) -> Interest {
-        if self.has_metrics_fields(meta) {
+        if self.is_metrics_event(meta) {
             Interest::always()
         } else {
             Interest::never()
@@ -415,10 +415,6 @@ impl<S> Layer<S> for MetricsLayer<S>
 where
     S: Subscriber + for<'span> LookupSpan<'span>,
 {
-    fn on_register_dispatch(&self, collector: &tracing_core::Dispatch) {
-        self.inner.on_register_dispatch(collector)
-    }
-
     fn on_layer(&mut self, subscriber: &mut S) {
         self.inner.on_layer(subscriber)
     }
@@ -460,10 +456,6 @@ where
         ctx: Context<'_, S>,
     ) {
         self.inner.on_follows_from(span, follows, ctx)
-    }
-
-    fn event_enabled(&self, event: &tracing_core::Event<'_>, ctx: Context<'_, S>) -> bool {
-        self.inner.event_enabled(event, ctx)
     }
 
     fn on_event(&self, event: &tracing_core::Event<'_>, ctx: Context<'_, S>) {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing-opentelemetry/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Support https://github.com/tokio-rs/tracing-opentelemetry/issues/32
This change will allow user to associate Attributes with metrics from tracing.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

1. MetricsLayer is only interested in events that contain fields with metrics prefixes such as `counter`, so I have utilized the [tracing_subscriber Filter trait](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/layer/#per-layer-filtering).
2. Since it's necessary to pass Attributes when outputting Measurements, it's required to complete the visit for all fields first before invoking the Metrics API(`Counter:add()`).
`SmallVec` is used to hold Attribute KeyValues, Metrics names, and Instruments for invocation, aiming to avoid allocations in typical use cases.



