### PR TITLE
Move off of opentelemetry in favor of separate crates.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,10 +22,11 @@ rust-version = "1.60.0"
 [features]
 default = ["tracing-log", "metrics"]
 # Enables support for exporting OpenTelemetry metrics
-metrics = ["opentelemetry/metrics", "smallvec"]
+metrics = ["opentelemetry/metrics","opentelemetry_sdk/metrics", "smallvec"]
 
 [dependencies]
 opentelemetry = { version = "0.20.0", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.20.0", default-features = false, features = ["trace"] }
 tracing = { version = "0.1.35", default-features = false, features = ["std"] }
 tracing-core = "0.1.28"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }

--- a/README.md
+++ b/README.md
@@ -59,8 +59,9 @@ The crate provides the following types:
 ### Basic Usage
 
 ```rust
-use opentelemetry::sdk::trace::TracerProvider;
 use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_sdk::trace::TracerProvider;
+use opentelemetry_stdout as stdout;
 use tracing::{error, span};
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::Registry;
@@ -68,7 +69,7 @@ use tracing_subscriber::Registry;
 fn main() {
     // Create a new OpenTelemetry trace pipeline that prints to stdout
     let provider = TracerProvider::builder()
-        .with_simple_exporter(opentelemetry_stdout::SpanExporter::default())
+        .with_simple_exporter(stdout::SpanExporter::default())
         .build();
     let tracer = provider.tracer("readme_example");
 

--- a/examples/opentelemetry-remote-context.rs
+++ b/examples/opentelemetry-remote-context.rs
@@ -1,5 +1,5 @@
-use opentelemetry::sdk::propagation::TraceContextPropagator;
 use opentelemetry::{global, Context};
+use opentelemetry_sdk::propagation::TraceContextPropagator;
 use std::collections::HashMap;
 use tracing::span;
 use tracing_opentelemetry::OpenTelemetrySpanExt;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,7 +51,7 @@
 //! ## Examples
 //!
 //! ```
-//! use opentelemetry::sdk::trace::TracerProvider;
+//! use opentelemetry_sdk::trace::TracerProvider;
 //! use opentelemetry::trace::{Tracer, TracerProvider as _};
 //! use tracing::{error, span};
 //! use tracing_subscriber::layer::SubscriberExt;

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -230,7 +230,7 @@ impl<'a> Visit for MetricVisitor<'a> {
 /// use tracing_opentelemetry::MetricsLayer;
 /// use tracing_subscriber::layer::SubscriberExt;
 /// use tracing_subscriber::Registry;
-/// # use opentelemetry::sdk::metrics::MeterProvider;
+/// # use opentelemetry_sdk::metrics::MeterProvider;
 ///
 /// // Constructing a MeterProvider is out-of-scope for the docs here, but there
 /// // are examples in the opentelemetry repository. See:

--- a/src/span_ext.rs
+++ b/src/span_ext.rs
@@ -17,7 +17,7 @@ pub trait OpenTelemetrySpanExt {
     ///
     /// ```rust
     /// use opentelemetry::{propagation::TextMapPropagator, trace::TraceContextExt};
-    /// use opentelemetry::sdk::propagation::TraceContextPropagator;
+    /// use opentelemetry_sdk::propagation::TraceContextPropagator;
     /// use tracing_opentelemetry::OpenTelemetrySpanExt;
     /// use std::collections::HashMap;
     /// use tracing::Span;
@@ -51,7 +51,7 @@ pub trait OpenTelemetrySpanExt {
     ///
     /// ```rust
     /// use opentelemetry::{propagation::TextMapPropagator, trace::TraceContextExt};
-    /// use opentelemetry::sdk::propagation::TraceContextPropagator;
+    /// use opentelemetry_sdk::propagation::TraceContextPropagator;
     /// use tracing_opentelemetry::OpenTelemetrySpanExt;
     /// use std::collections::HashMap;
     /// use tracing::Span;

--- a/tests/trace_state_propagation.rs
+++ b/tests/trace_state_propagation.rs
@@ -1,13 +1,13 @@
 use futures_util::future::BoxFuture;
 use opentelemetry::{
     propagation::TextMapPropagator,
-    sdk::{
-        export::trace::{ExportResult, SpanData, SpanExporter},
-        propagation::{BaggagePropagator, TextMapCompositePropagator, TraceContextPropagator},
-        trace::{Tracer, TracerProvider},
-    },
     trace::{SpanContext, TraceContextExt, Tracer as _, TracerProvider as _},
     Context,
+};
+use opentelemetry_sdk::{
+    export::trace::{ExportResult, SpanData, SpanExporter},
+    propagation::{BaggagePropagator, TextMapCompositePropagator, TraceContextPropagator},
+    trace::{Tracer, TracerProvider},
 };
 use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};


### PR DESCRIPTION
## Motivation

`opentelemetry` is going to be deprecated in favor of separated crates.


## Solution

Use the `opentelemetry_sdk` crate for SDK calls instead of `opentelemetry::sdk`