### PR TITLE
fix: trace id did not match when propagating invalid context

### DIFF
--- a/src/span_ext.rs
+++ b/src/span_ext.rs
@@ -143,7 +143,6 @@ impl OpenTelemetrySpanExt for tracing::Span {
                 get_context.with_context(subscriber, id, move |data, _tracer| {
                     if let Some(cx) = cx.take() {
                         data.parent_cx = cx;
-                        data.builder.trace_id = None;
                     }
                 });
             }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing-opentelemetry/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->
Fix following issues
* https://github.com/tokio-rs/tracing-opentelemetry/issues/54
* https://github.com/tokio-rs/tracing-opentelemetry/issues/45

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

* Revert https://github.com/tokio-rs/tracing-opentelemetry/pull/26/files
* When an invalid(empty) Context is extracted from the propagator and passed to OpenTelemetrySpanExt::set_parent(), if none is set for trace_id, root and child trace id will not match
* I can confirm that this change works in [reproduction](https://github.com/notheotherben/tracing-opentelemetry-traceid-repro) that @notheotherben created
* add regression test case which propagate empty context
