### PR TITLE
Prepare for v0.21.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,19 @@
+# 0.21.0 (August 1, 2023)
+
+### Added
+
+- Ability to produce measurement with attributes (#43)
+
+### Changed
+
+- Depend on `opentelemetry_sdk` directly instead of `opentelemetry::sdk` (#48)
+
+### Fixed
+
+- Trace IDs not matching when propagating invalid contexts (#55)
+
+Thanks to @ymgyt and @hdost for contributing to this release!
+
 # 0.20.0 (August 1, 2023)
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,18 +1,22 @@
-# 0.21.0 (August 1, 2023)
+# 0.21.0 (August 28, 2023)
 
 ### Added
 
 - Ability to produce measurement with attributes (#43)
 
-### Changed
+### Breaking Changes
 
 - Depend on `opentelemetry_sdk` directly instead of `opentelemetry::sdk` (#48)
+- `MetricsLayer` is now generic over the its `Subscriber` impl to support
+  [per-layer filtering] (#43)
 
 ### Fixed
 
 - Trace IDs not matching when propagating invalid contexts (#55)
 
 Thanks to @ymgyt and @hdost for contributing to this release!
+
+[per-layer filtering]: https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/layer/index.html#per-layer-filtering
 
 # 0.20.0 (August 1, 2023)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@
 
 ### Breaking Changes
 
-- Depend on `opentelemetry_sdk` directly instead of `opentelemetry::sdk` (#48)
 - `MetricsLayer` is now generic over the its `Subscriber` impl to support
   [per-layer filtering] (#43)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.20.0"
+version = "0.21.0"
 authors = [
     "Julian Tescher <julian@tescher.me>",
     "Tokio Contributors <team@tokio.rs>"

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-opentelemetry.svg
-[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.19.0
+[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.21.0
 [docs-badge]: https://docs.rs/tracing-opentelemetry/badge.svg
-[docs-url]: https://docs.rs/tracing-opentelemetry/0.19.0/tracing_opentelemetry
+[docs-url]: https://docs.rs/tracing-opentelemetry/0.21.0/tracing_opentelemetry
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_opentelemetry
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -97,7 +97,7 @@ fn main() {
 opentelemetry = "0.20"
 opentelemetry-stdout = { version = "0.1.0", features = ["trace"] }
 tracing = "0.1"
-tracing-opentelemetry = "0.20"
+tracing-opentelemetry = "0.21"
 tracing-subscriber = "0.3"
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@
 //! [subscriber]: tracing_subscriber::subscribe
 #![deny(unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.19.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.21.0")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing-opentelemetry/issues/"


### PR DESCRIPTION
Changelog:

### Added

- Ability to produce measurement with attributes (#43)

### Breaking Changes

- `MetricsLayer` is now generic over the its `Subscriber` impl to support [per-layer filtering] (#43)

### Fixed

- Trace IDs not matching when propagating invalid contexts (#55)

[per-layer filtering]: https://docs.rs/tracing-subscriber/0.3.17/tracing_subscriber/layer/index.html#per-layer-filtering