### PR TITLE
WASM Support

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,10 @@ tracing-subscriber = { version = "0.3.0", default-features = false, features = [
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
 pprof = { version = "0.11.1", features = ["flamegraph", "criterion"] }
 
+[target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
+js-sys = "0.3.64"
+web-time = "0.2.0"
+
 [lib]
 bench = false
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,3 +150,17 @@ pub struct OtelData {
     /// The otel span data recorded during the current tracing span.
     pub builder: opentelemetry::trace::SpanBuilder,
 }
+
+pub(crate) mod time {
+    use std::time::SystemTime;
+
+    #[cfg(not(target_arch = "wasm32"))]
+    pub(crate) fn now() -> SystemTime {
+        SystemTime::now()
+    }
+
+    #[cfg(target_arch = "wasm32")]
+    pub(crate) fn now() -> SystemTime {
+        SystemTime::UNIX_EPOCH + std::time::Duration::from_millis(js_sys::Date::now() as u64)
+    }
+}


### PR DESCRIPTION
- add a time module at the root with a now implementation that is replaced with a js_sys call when compiling for wasm32
- use Instant from web_time when targeting wasm32
- add js_sys and web_time dependencies when targeting wasm32

## Motivation

I was attempting to use this library with a wasm target in a browser. If you call `std::time::{Instant, SystemTime}::now` in a wasm target, it will panic at runtime. This library makes use of both `::now()` calls, which will result in a panic when attempting to record a trace.

## Solution

In the library that this library calls (`opentelemetry-api`), this is resolved by replacing calls to `SystemTime::now()` with an implementation that returns a `SystemTime` constructed from `js_sys::Date`. To preserve the ability to pass `SystemTime`-typed args to `opentelemetry_api` methods, I just added the same mechanism to this library.

Because `Instant` is never used in `opentelemetry_api`, we can instead replace the implementation entirely with the api-compatible "polyfill" from `web_time`.

All of these changes are behind `cfg` and automatically enabled when building for `wasm32` targets, so this will not change any behavior/performance when built for other targets.
