### PR TITLE
Update README example Cargo.toml

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ fn main() {
 ```toml
 [dependencies]
 opentelemetry = "0.20"
+opentelemetry_sdk = "0.20"
 opentelemetry-stdout = { version = "0.1.0", features = ["trace"] }
 tracing = "0.1"
 tracing-opentelemetry = "0.21"


### PR DESCRIPTION
The `Cargo.toml` is missing the `opentelemetry_sdk` dependency to get the `Basic Usage` example working.

## Motivation

Ensure new users to tracing-otel can get up and running easily with the provided example.

## Solution

Update the `Cargo.toml` to the correct set of deps used in the README example.
