### PR TITLE
Prepare for v0.22.0 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,18 @@
-# Unreleased
+# 0.22.0 (November 7, 2023)
 
 ### Breaking Changes
 
 - Upgrade to `v0.21.0` of `opentelemetry`
   For list of breaking changes in OpenTelemetry, see the
   [v0.21.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/v0.21.0/opentelemetry/CHANGELOG.md).
-- Update MSRV to require Rust 1.65+, as `opentelemetry` requires it now.
+- Update MSRV to require Rust 1.65+, as `opentelemetry` requires it now. (#68)
+
+### Fixed
+
+- WASM Support (#57)
+- Fix potential deadlock (#59)
+
+Thanks to @jesseditson, @AsmPrgmC3, and @rthomas for contributing to this release!
 
 # 0.21.0 (August 28, 2023)
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.21.0"
+version = "0.22.0"
 authors = [
     "Julian Tescher <julian@tescher.me>",
     "Tokio Contributors <team@tokio.rs>"

--- a/README.md
+++ b/README.md
@@ -17,9 +17,9 @@ Utilities for adding [OpenTelemetry] interoperability to [`tracing`].
 [Documentation][docs-url] | [Chat][discord-url]
 
 [crates-badge]: https://img.shields.io/crates/v/tracing-opentelemetry.svg
-[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.21.0
+[crates-url]: https://crates.io/crates/tracing-opentelemetry/0.22.0
 [docs-badge]: https://docs.rs/tracing-opentelemetry/badge.svg
-[docs-url]: https://docs.rs/tracing-opentelemetry/0.21.0/tracing_opentelemetry
+[docs-url]: https://docs.rs/tracing-opentelemetry/0.22.0/tracing_opentelemetry
 [docs-master-badge]: https://img.shields.io/badge/docs-master-blue
 [docs-master-url]: https://tracing-rs.netlify.com/tracing_opentelemetry
 [mit-badge]: https://img.shields.io/badge/license-MIT-blue.svg
@@ -94,11 +94,11 @@ fn main() {
 `Cargo.toml`
 ```toml
 [dependencies]
-opentelemetry = "0.20"
-opentelemetry_sdk = "0.20"
-opentelemetry-stdout = { version = "0.1.0", features = ["trace"] }
+opentelemetry = "0.21"
+opentelemetry_sdk = "0.21"
+opentelemetry-stdout = { version = "0.2.0", features = ["trace"] }
 tracing = "0.1"
-tracing-opentelemetry = "0.21"
+tracing-opentelemetry = "0.22"
 tracing-subscriber = "0.3"
 ```
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -106,7 +106,7 @@
 //! [subscriber]: tracing_subscriber::subscribe
 #![deny(unreachable_pub)]
 #![cfg_attr(test, deny(warnings))]
-#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.21.0")]
+#![doc(html_root_url = "https://docs.rs/tracing-opentelemetry/0.22.0")]
 #![doc(
     html_logo_url = "https://raw.githubusercontent.com/tokio-rs/tracing/master/assets/logo-type.png",
     issue_tracker_base_url = "https://github.com/tokio-rs/tracing-opentelemetry/issues/"


### PR DESCRIPTION
Changelog:

### Breaking Changes

- Upgrade to `v0.21.0` of `opentelemetry` For list of breaking changes in OpenTelemetry, see the [v0.21.0 changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/v0.21.0/opentelemetry/CHANGELOG.md).
- Update MSRV to require Rust 1.65+, as `opentelemetry` requires it now. (#68)

### Fixed

- WASM Support (#57)
- Fix potential deadlock (#59)