### PR TITLE
Relax opentelemetry dependencies to optimisically use patches

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,12 +41,12 @@ smallvec = { version = "1.0", optional = true }
 [dev-dependencies]
 async-trait = "0.1.56"
 criterion = { version = "0.5.1", default-features = false, features = ["html_reports"] }
-opentelemetry = { version = "0.21.0", features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.21.0", default-features = false, features = ["trace", "rt-tokio"] }
-opentelemetry-jaeger = "0.20.0"
-opentelemetry-stdout = { version = "0.2.0", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.14.0", features = ["metrics"] }
-opentelemetry-semantic-conventions = "0.13.0"
+opentelemetry = { version = "0.21", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.21", default-features = false, features = ["trace", "rt-tokio"] }
+opentelemetry-jaeger = "0.20"
+opentelemetry-stdout = { version = "0.2", features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.14", features = ["metrics"] }
+opentelemetry-semantic-conventions = "0.13"
 futures-util = { version = "0.3", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing-opentelemetry/blob/master/CONTRIBUTING.md
-->

## Motivation

While trying to submit a bugfix in https://github.com/open-telemetry/opentelemetry-rust, I had versioning issues where the workspace crates would rely on `opentelemetry_sdk = "0.21.1"`, but since it's pinned to "0.21.0" in `tracing-opentelemetry` the resolution would cause conflicts. 

## Solution

I currently relaxed all the `opentelemetry` related crates versions, which should make upgrading a bit easier. Alternatively, I can simply bump the version of `opentelemetry_sdk` to "0.21.1" if that's preferred.

Thank you!