### PR TITLE
Display attribute in metrics

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -145,8 +145,9 @@ pub(crate) struct MetricVisitor<'a> {
 }
 
 impl<'a> Visit for MetricVisitor<'a> {
-    fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {
-        // Do nothing
+    fn record_debug(&mut self, field: &Field, value: &dyn fmt::Debug) {
+        self.attributes
+            .push(KeyValue::new(field.name(), format!("{value:?}")));
     }
 
     fn record_u64(&mut self, field: &Field, value: u64) {

--- a/tests/metrics_publishing.rs
+++ b/tests/metrics_publishing.rs
@@ -164,22 +164,6 @@ async fn f64_histogram_is_exported() {
     exporter.export().unwrap();
 }
 
-struct DisplayAttribute(String);
-
-impl std::fmt::Display for DisplayAttribute {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "display: {}", self.0)
-    }
-}
-
-struct DebugAttribute(String);
-
-impl std::fmt::Debug for DebugAttribute {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "debug: {}", self.0)
-    }
-}
-
 #[tokio::test]
 async fn u64_counter_with_attributes_is_exported() {
     let (subscriber, exporter) = init_subscriber(
@@ -193,15 +177,10 @@ async fn u64_counter_with_attributes_is_exported() {
                 KeyValue::new("f64_key_1", 3_f64),
                 KeyValue::new("str_key_1", "foo"),
                 KeyValue::new("bool_key_1", true),
-                KeyValue::new("display_key_1", "display: bar"),
-                KeyValue::new("debug_key_1", "debug: baz"),
             ]
             .as_slice(),
         )),
     );
-
-    let display_attribute = DisplayAttribute("bar".to_string());
-    let debug_attribute = DebugAttribute("baz".to_string());
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
@@ -211,8 +190,6 @@ async fn u64_counter_with_attributes_is_exported() {
             f64_key_1 = 3_f64,
             str_key_1 = "foo",
             bool_key_1 = true,
-            display_key_1 = %display_attribute,
-            debug_key_1 = ?debug_attribute,
         );
     });
 
@@ -232,15 +209,10 @@ async fn f64_counter_with_attributes_is_exported() {
                 KeyValue::new("f64_key_1", 3_f64),
                 KeyValue::new("str_key_1", "foo"),
                 KeyValue::new("bool_key_1", true),
-                KeyValue::new("display_key_1", "display: bar"),
-                KeyValue::new("debug_key_1", "debug: baz"),
             ]
             .as_slice(),
         )),
     );
-
-    let display_attribute = DisplayAttribute("bar".to_string());
-    let debug_attribute = DebugAttribute("baz".to_string());
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
@@ -250,8 +222,6 @@ async fn f64_counter_with_attributes_is_exported() {
             f64_key_1 = 3_f64,
             str_key_1 = "foo",
             bool_key_1 = true,
-            display_key_1 = %display_attribute,
-            debug_key_1 = ?debug_attribute,
         );
     });
 
@@ -271,15 +241,10 @@ async fn i64_up_down_counter_with_attributes_is_exported() {
                 KeyValue::new("f64_key_1", 3_f64),
                 KeyValue::new("str_key_1", "foo"),
                 KeyValue::new("bool_key_1", true),
-                KeyValue::new("display_key_1", "display: bar"),
-                KeyValue::new("debug_key_1", "debug: baz"),
             ]
             .as_slice(),
         )),
     );
-
-    let display_attribute = DisplayAttribute("bar".to_string());
-    let debug_attribute = DebugAttribute("baz".to_string());
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
@@ -289,8 +254,6 @@ async fn i64_up_down_counter_with_attributes_is_exported() {
             f64_key_1 = 3_f64,
             str_key_1 = "foo",
             bool_key_1 = true,
-            display_key_1 = %display_attribute,
-            debug_key_1 = ?debug_attribute,
         );
     });
 
@@ -310,15 +273,10 @@ async fn f64_up_down_counter_with_attributes_is_exported() {
                 KeyValue::new("f64_key_1", 3_f64),
                 KeyValue::new("str_key_1", "foo"),
                 KeyValue::new("bool_key_1", true),
-                KeyValue::new("display_key_1", "display: bar"),
-                KeyValue::new("debug_key_1", "debug: baz"),
             ]
             .as_slice(),
         )),
     );
-
-    let display_attribute = DisplayAttribute("bar".to_string());
-    let debug_attribute = DebugAttribute("baz".to_string());
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
@@ -328,8 +286,6 @@ async fn f64_up_down_counter_with_attributes_is_exported() {
             f64_key_1 = 3_f64,
             str_key_1 = "foo",
             bool_key_1 = true,
-            display_key_1 = %display_attribute,
-            debug_key_1 = ?debug_attribute,
         );
     });
 
@@ -349,15 +305,10 @@ async fn u64_histogram_with_attributes_is_exported() {
                 KeyValue::new("f64_key_1", 3_f64),
                 KeyValue::new("str_key_1", "foo"),
                 KeyValue::new("bool_key_1", true),
-                KeyValue::new("display_key_1", "display: bar"),
-                KeyValue::new("debug_key_1", "debug: baz"),
             ]
             .as_slice(),
         )),
     );
-
-    let display_attribute = DisplayAttribute("bar".to_string());
-    let debug_attribute = DebugAttribute("baz".to_string());
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
@@ -367,8 +318,6 @@ async fn u64_histogram_with_attributes_is_exported() {
             f64_key_1 = 3_f64,
             str_key_1 = "foo",
             bool_key_1 = true,
-            display_key_1 = %display_attribute,
-            debug_key_1 = ?debug_attribute,
         );
     });
 
@@ -388,15 +337,10 @@ async fn i64_histogram_with_attributes_is_exported() {
                 KeyValue::new("f64_key_1", 3_f64),
                 KeyValue::new("str_key_1", "foo"),
                 KeyValue::new("bool_key_1", true),
-                KeyValue::new("display_key_1", "display: bar"),
-                KeyValue::new("debug_key_1", "debug: baz"),
             ]
             .as_slice(),
         )),
     );
-
-    let display_attribute = DisplayAttribute("bar".to_string());
-    let debug_attribute = DebugAttribute("baz".to_string());
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
@@ -406,8 +350,6 @@ async fn i64_histogram_with_attributes_is_exported() {
             f64_key_1 = 3_f64,
             str_key_1 = "foo",
             bool_key_1 = true,
-            display_key_1 = %display_attribute,
-            debug_key_1 = ?debug_attribute,
         );
     });
 
@@ -427,15 +369,10 @@ async fn f64_histogram_with_attributes_is_exported() {
                 KeyValue::new("f64_key_1", 3_f64),
                 KeyValue::new("str_key_1", "foo"),
                 KeyValue::new("bool_key_1", true),
-                KeyValue::new("display_key_1", "display: bar"),
-                KeyValue::new("debug_key_1", "debug: baz"),
             ]
             .as_slice(),
         )),
     );
-
-    let display_attribute = DisplayAttribute("bar".to_string());
-    let debug_attribute = DebugAttribute("baz".to_string());
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
@@ -445,7 +382,67 @@ async fn f64_histogram_with_attributes_is_exported() {
             f64_key_1 = 3_f64,
             str_key_1 = "foo",
             bool_key_1 = true,
+        );
+    });
+
+    exporter.export().unwrap();
+}
+
+#[tokio::test]
+async fn display_attribute_is_exported() {
+    let (subscriber, exporter) = init_subscriber(
+        "hello_world".to_string(),
+        InstrumentKind::Counter,
+        1_u64,
+        Some(AttributeSet::from(
+            [KeyValue::new("display_key_1", "display: foo")].as_slice(),
+        )),
+    );
+
+    struct DisplayAttribute(String);
+
+    impl std::fmt::Display for DisplayAttribute {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "display: {}", self.0)
+        }
+    }
+
+    let display_attribute = DisplayAttribute("foo".to_string());
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(
+            monotonic_counter.hello_world = 1_u64,
             display_key_1 = %display_attribute,
+        );
+    });
+
+    exporter.export().unwrap();
+}
+
+#[tokio::test]
+async fn debug_attribute_is_exported() {
+    let (subscriber, exporter) = init_subscriber(
+        "hello_world".to_string(),
+        InstrumentKind::Counter,
+        1_u64,
+        Some(AttributeSet::from(
+            [KeyValue::new("debug_key_1", "debug: foo")].as_slice(),
+        )),
+    );
+
+    struct DebugAttribute(String);
+
+    impl std::fmt::Debug for DebugAttribute {
+        fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+            write!(f, "debug: {}", self.0)
+        }
+    }
+
+    let debug_attribute = DebugAttribute("foo".to_string());
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(
+            monotonic_counter.hello_world = 1_u64,
             debug_key_1 = ?debug_attribute,
         );
     });

--- a/tests/metrics_publishing.rs
+++ b/tests/metrics_publishing.rs
@@ -164,6 +164,22 @@ async fn f64_histogram_is_exported() {
     exporter.export().unwrap();
 }
 
+struct DisplayAttribute(String);
+
+impl std::fmt::Display for DisplayAttribute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "display: {}", self.0)
+    }
+}
+
+struct DebugAttribute(String);
+
+impl std::fmt::Debug for DebugAttribute {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "debug: {}", self.0)
+    }
+}
+
 #[tokio::test]
 async fn u64_counter_with_attributes_is_exported() {
     let (subscriber, exporter) = init_subscriber(
@@ -177,10 +193,15 @@ async fn u64_counter_with_attributes_is_exported() {
                 KeyValue::new("f64_key_1", 3_f64),
                 KeyValue::new("str_key_1", "foo"),
                 KeyValue::new("bool_key_1", true),
+                KeyValue::new("display_key_1", "display: bar"),
+                KeyValue::new("debug_key_1", "debug: baz"),
             ]
             .as_slice(),
         )),
     );
+
+    let display_attribute = DisplayAttribute("bar".to_string());
+    let debug_attribute = DebugAttribute("baz".to_string());
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
@@ -190,6 +211,8 @@ async fn u64_counter_with_attributes_is_exported() {
             f64_key_1 = 3_f64,
             str_key_1 = "foo",
             bool_key_1 = true,
+            display_key_1 = %display_attribute,
+            debug_key_1 = ?debug_attribute,
         );
     });
 
@@ -209,10 +232,15 @@ async fn f64_counter_with_attributes_is_exported() {
                 KeyValue::new("f64_key_1", 3_f64),
                 KeyValue::new("str_key_1", "foo"),
                 KeyValue::new("bool_key_1", true),
+                KeyValue::new("display_key_1", "display: bar"),
+                KeyValue::new("debug_key_1", "debug: baz"),
             ]
             .as_slice(),
         )),
     );
+
+    let display_attribute = DisplayAttribute("bar".to_string());
+    let debug_attribute = DebugAttribute("baz".to_string());
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
@@ -222,6 +250,8 @@ async fn f64_counter_with_attributes_is_exported() {
             f64_key_1 = 3_f64,
             str_key_1 = "foo",
             bool_key_1 = true,
+            display_key_1 = %display_attribute,
+            debug_key_1 = ?debug_attribute,
         );
     });
 
@@ -241,10 +271,15 @@ async fn i64_up_down_counter_with_attributes_is_exported() {
                 KeyValue::new("f64_key_1", 3_f64),
                 KeyValue::new("str_key_1", "foo"),
                 KeyValue::new("bool_key_1", true),
+                KeyValue::new("display_key_1", "display: bar"),
+                KeyValue::new("debug_key_1", "debug: baz"),
             ]
             .as_slice(),
         )),
     );
+
+    let display_attribute = DisplayAttribute("bar".to_string());
+    let debug_attribute = DebugAttribute("baz".to_string());
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
@@ -254,6 +289,8 @@ async fn i64_up_down_counter_with_attributes_is_exported() {
             f64_key_1 = 3_f64,
             str_key_1 = "foo",
             bool_key_1 = true,
+            display_key_1 = %display_attribute,
+            debug_key_1 = ?debug_attribute,
         );
     });
 
@@ -273,10 +310,15 @@ async fn f64_up_down_counter_with_attributes_is_exported() {
                 KeyValue::new("f64_key_1", 3_f64),
                 KeyValue::new("str_key_1", "foo"),
                 KeyValue::new("bool_key_1", true),
+                KeyValue::new("display_key_1", "display: bar"),
+                KeyValue::new("debug_key_1", "debug: baz"),
             ]
             .as_slice(),
         )),
     );
+
+    let display_attribute = DisplayAttribute("bar".to_string());
+    let debug_attribute = DebugAttribute("baz".to_string());
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
@@ -286,6 +328,8 @@ async fn f64_up_down_counter_with_attributes_is_exported() {
             f64_key_1 = 3_f64,
             str_key_1 = "foo",
             bool_key_1 = true,
+            display_key_1 = %display_attribute,
+            debug_key_1 = ?debug_attribute,
         );
     });
 
@@ -305,10 +349,15 @@ async fn u64_histogram_with_attributes_is_exported() {
                 KeyValue::new("f64_key_1", 3_f64),
                 KeyValue::new("str_key_1", "foo"),
                 KeyValue::new("bool_key_1", true),
+                KeyValue::new("display_key_1", "display: bar"),
+                KeyValue::new("debug_key_1", "debug: baz"),
             ]
             .as_slice(),
         )),
     );
+
+    let display_attribute = DisplayAttribute("bar".to_string());
+    let debug_attribute = DebugAttribute("baz".to_string());
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
@@ -318,6 +367,8 @@ async fn u64_histogram_with_attributes_is_exported() {
             f64_key_1 = 3_f64,
             str_key_1 = "foo",
             bool_key_1 = true,
+            display_key_1 = %display_attribute,
+            debug_key_1 = ?debug_attribute,
         );
     });
 
@@ -337,10 +388,15 @@ async fn i64_histogram_with_attributes_is_exported() {
                 KeyValue::new("f64_key_1", 3_f64),
                 KeyValue::new("str_key_1", "foo"),
                 KeyValue::new("bool_key_1", true),
+                KeyValue::new("display_key_1", "display: bar"),
+                KeyValue::new("debug_key_1", "debug: baz"),
             ]
             .as_slice(),
         )),
     );
+
+    let display_attribute = DisplayAttribute("bar".to_string());
+    let debug_attribute = DebugAttribute("baz".to_string());
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
@@ -350,6 +406,8 @@ async fn i64_histogram_with_attributes_is_exported() {
             f64_key_1 = 3_f64,
             str_key_1 = "foo",
             bool_key_1 = true,
+            display_key_1 = %display_attribute,
+            debug_key_1 = ?debug_attribute,
         );
     });
 
@@ -369,10 +427,15 @@ async fn f64_histogram_with_attributes_is_exported() {
                 KeyValue::new("f64_key_1", 3_f64),
                 KeyValue::new("str_key_1", "foo"),
                 KeyValue::new("bool_key_1", true),
+                KeyValue::new("display_key_1", "display: bar"),
+                KeyValue::new("debug_key_1", "debug: baz"),
             ]
             .as_slice(),
         )),
     );
+
+    let display_attribute = DisplayAttribute("bar".to_string());
+    let debug_attribute = DebugAttribute("baz".to_string());
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
@@ -382,6 +445,8 @@ async fn f64_histogram_with_attributes_is_exported() {
             f64_key_1 = 3_f64,
             str_key_1 = "foo",
             bool_key_1 = true,
+            display_key_1 = %display_attribute,
+            debug_key_1 = ?debug_attribute,
         );
     });
 


### PR DESCRIPTION
Closes #81

Adds metrics attributes given as Display or Debug

<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing-opentelemetry/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

As described in #81, currently the metrics layer doesn't do anything when Debug / Display values are given like so:

```rust
tracing::info!(
            counter.myapp.organization = 1,
            %organization.status,
            ?organization.type
);
```

This implements `MetricsVisitor::record_debug` so that it can export them as metrics attributes.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Push the given argument to the `self.attributes` in `MetricsVisitor::record_debug` where it does nothing currently like it does for str value:

https://github.com/tokio-rs/tracing-opentelemetry/blob/v0.1.x/src/metrics.rs#L148-L150

```rust
fn record_debug(&mut self, _field: &Field, _value: &dyn fmt::Debug) {
        // Do nothing
}
```

https://github.com/tokio-rs/tracing-opentelemetry/blob/v0.1.x/src/metrics.rs#L208-L211

```rust
fn record_str(&mut self, field: &Field, value: &str) {
        self.attributes
            .push(KeyValue::new(field.name(), value.to_owned()));
}
```