### PR TITLE
remove i64_histogram support

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -30,7 +30,6 @@ pub(crate) struct Instruments {
     i64_up_down_counter: MetricsMap<UpDownCounter<i64>>,
     f64_up_down_counter: MetricsMap<UpDownCounter<f64>>,
     u64_histogram: MetricsMap<Histogram<u64>>,
-    i64_histogram: MetricsMap<Histogram<i64>>,
     f64_histogram: MetricsMap<Histogram<f64>>,
 }
 
@@ -43,7 +42,6 @@ pub(crate) enum InstrumentType {
     UpDownCounterI64(i64),
     UpDownCounterF64(f64),
     HistogramU64(u64),
-    HistogramI64(i64),
     HistogramF64(f64),
 }
 
@@ -119,14 +117,6 @@ impl Instruments {
                     |rec| rec.record(value, attributes),
                 );
             }
-            InstrumentType::HistogramI64(value) => {
-                update_or_insert(
-                    &self.i64_histogram,
-                    metric_name,
-                    || meter.i64_histogram(metric_name).init(),
-                    |rec| rec.record(value, attributes),
-                );
-            }
             InstrumentType::HistogramF64(value) => {
                 update_or_insert(
                     &self.f64_histogram,
@@ -198,9 +188,6 @@ impl<'a> Visit for MetricVisitor<'a> {
         } else if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_COUNTER) {
             self.visited_metrics
                 .push((metric_name, InstrumentType::UpDownCounterI64(value)));
-        } else if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_HISTOGRAM) {
-            self.visited_metrics
-                .push((metric_name, InstrumentType::HistogramI64(value)));
         } else {
             self.attributes.push(KeyValue::new(field.name(), value));
         }

--- a/tests/metrics_publishing.rs
+++ b/tests/metrics_publishing.rs
@@ -133,22 +133,6 @@ async fn u64_histogram_is_exported() {
 }
 
 #[tokio::test]
-async fn i64_histogram_is_exported() {
-    let (subscriber, exporter) = init_subscriber(
-        "abcdefg_auenatsou".to_string(),
-        InstrumentKind::Histogram,
-        -19_i64,
-        None,
-    );
-
-    tracing::subscriber::with_default(subscriber, || {
-        tracing::info!(histogram.abcdefg_auenatsou = -19_i64);
-    });
-
-    exporter.export().unwrap();
-}
-
-#[tokio::test]
 async fn f64_histogram_is_exported() {
     let (subscriber, exporter) = init_subscriber(
         "abcdefg_racecar".to_string(),
@@ -313,38 +297,6 @@ async fn u64_histogram_with_attributes_is_exported() {
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
             histogram.hello_world = 1_u64,
-            u64_key_1 = 1_u64,
-            i64_key_1 = 2_i64,
-            f64_key_1 = 3_f64,
-            str_key_1 = "foo",
-            bool_key_1 = true,
-        );
-    });
-
-    exporter.export().unwrap();
-}
-
-#[tokio::test]
-async fn i64_histogram_with_attributes_is_exported() {
-    let (subscriber, exporter) = init_subscriber(
-        "hello_world".to_string(),
-        InstrumentKind::Histogram,
-        -1_i64,
-        Some(AttributeSet::from(
-            [
-                KeyValue::new("u64_key_1", 1_i64),
-                KeyValue::new("i64_key_1", 2_i64),
-                KeyValue::new("f64_key_1", 3_f64),
-                KeyValue::new("str_key_1", "foo"),
-                KeyValue::new("bool_key_1", true),
-            ]
-            .as_slice(),
-        )),
-    );
-
-    tracing::subscriber::with_default(subscriber, || {
-        tracing::info!(
-            histogram.hello_world = -1_i64,
             u64_key_1 = 1_u64,
             i64_key_1 = 2_i64,
             f64_key_1 = 3_f64,


### PR DESCRIPTION
rust-opentelemetry has dropped this, as it is
recommended against by the otel spec.