### PR TITLE
enhancement: add gauge metric behind feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,8 @@ rust-version = "1.65.0"
 default = ["tracing-log", "metrics"]
 # Enables support for exporting OpenTelemetry metrics
 metrics = ["opentelemetry/metrics","opentelemetry_sdk/metrics", "smallvec"]
+# Enables support for unstable OpenTelemetry metric instruments
+otel_unstable = ["opentelemetry/otel_unstable"]
 
 [dependencies]
 opentelemetry = { version = "0.22.0", default-features = false, features = ["trace"] }

--- a/tests/metrics_publishing.rs
+++ b/tests/metrics_publishing.rs
@@ -1,7 +1,7 @@
 use opentelemetry::{metrics::MetricsError, KeyValue};
 use opentelemetry_sdk::{
     metrics::{
-        data::{self, Histogram, Sum},
+        data::{self, Histogram, Sum, Gauge},
         reader::{
             AggregationSelector, DefaultAggregationSelector, DefaultTemporalitySelector,
             MetricReader, TemporalitySelector,
@@ -110,6 +110,54 @@ async fn f64_up_down_counter_is_exported() {
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(counter.pebcak_blah = 99.123_f64);
+    });
+
+    exporter.export().unwrap();
+}
+
+#[tokio::test]
+async fn u64_gauge_is_exported() {
+    let (subscriber, exporter) = init_subscriber(
+        "gygygy".to_string(),
+        InstrumentKind::Gauge,
+        1_u64,
+        None,
+    );
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(gauge.gygygy = 1_u64);
+    });
+
+    exporter.export().unwrap();
+}
+
+#[tokio::test]
+async fn f64_gauge_is_exported() {
+    let (subscriber, exporter) = init_subscriber(
+        "huitt".to_string(),
+        InstrumentKind::Gauge,
+        1_f64,
+        None,
+    );
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(gauge.huitt = 1_f64);
+    });
+
+    exporter.export().unwrap();
+}
+
+#[tokio::test]
+async fn i64_gauge_is_exported() {
+    let (subscriber, exporter) = init_subscriber(
+        "samsagaz".to_string(),
+        InstrumentKind::Gauge,
+        1_i64,
+        None,
+    );
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(gauge.samsagaz = 1_i64);
     });
 
     exporter.export().unwrap();
@@ -264,6 +312,102 @@ async fn f64_up_down_counter_with_attributes_is_exported() {
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(
             counter.hello_world = -1_f64,
+            u64_key_1 = 1_u64,
+            i64_key_1 = 2_i64,
+            f64_key_1 = 3_f64,
+            str_key_1 = "foo",
+            bool_key_1 = true,
+        );
+    });
+
+    exporter.export().unwrap();
+}
+
+#[tokio::test]
+async fn f64_gauge_with_attributes_is_exported() {
+    let (subscriber, exporter) = init_subscriber(
+        "hello_world".to_string(),
+        InstrumentKind::Counter,
+        1_f64,
+        Some(AttributeSet::from(
+            [
+                KeyValue::new("u64_key_1", 1_i64),
+                KeyValue::new("i64_key_1", 2_i64),
+                KeyValue::new("f64_key_1", 3_f64),
+                KeyValue::new("str_key_1", "foo"),
+                KeyValue::new("bool_key_1", true),
+            ]
+            .as_slice(),
+        )),
+    );
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(
+            gauge.hello_world = 1_f64,
+            u64_key_1 = 1_u64,
+            i64_key_1 = 2_i64,
+            f64_key_1 = 3_f64,
+            str_key_1 = "foo",
+            bool_key_1 = true,
+        );
+    });
+
+    exporter.export().unwrap();
+}
+
+#[tokio::test]
+async fn u64_gauge_with_attributes_is_exported() {
+    let (subscriber, exporter) = init_subscriber(
+        "hello_world".to_string(),
+        InstrumentKind::Counter,
+        1_u64,
+        Some(AttributeSet::from(
+            [
+                KeyValue::new("u64_key_1", 1_i64),
+                KeyValue::new("i64_key_1", 2_i64),
+                KeyValue::new("f64_key_1", 3_f64),
+                KeyValue::new("str_key_1", "foo"),
+                KeyValue::new("bool_key_1", true),
+            ]
+            .as_slice(),
+        )),
+    );
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(
+            gauge.hello_world = 1_u64,
+            u64_key_1 = 1_u64,
+            i64_key_1 = 2_i64,
+            f64_key_1 = 3_f64,
+            str_key_1 = "foo",
+            bool_key_1 = true,
+        );
+    });
+
+    exporter.export().unwrap();
+}
+
+#[tokio::test]
+async fn i64_gauge_with_attributes_is_exported() {
+    let (subscriber, exporter) = init_subscriber(
+        "hello_world".to_string(),
+        InstrumentKind::Counter,
+        1_i64,
+        Some(AttributeSet::from(
+            [
+                KeyValue::new("u64_key_1", 1_i64),
+                KeyValue::new("i64_key_1", 2_i64),
+                KeyValue::new("f64_key_1", 3_f64),
+                KeyValue::new("str_key_1", "foo"),
+                KeyValue::new("bool_key_1", true),
+            ]
+            .as_slice(),
+        )),
+    );
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(
+            gauge.hello_world = 1_i64,
             u64_key_1 = 1_u64,
             i64_key_1 = 2_i64,
             f64_key_1 = 3_f64,
@@ -513,6 +657,22 @@ where
 
                         if let Some(expected_attributes) = self.expected_attributes.as_ref() {
                             sum.data_points.iter().for_each(|data_point| {
+                                assert_eq!(expected_attributes, &data_point.attributes,)
+                            });
+                        }
+                    }
+                    InstrumentKind::Gauge => {
+                        let gauge = metric.data.as_any().downcast_ref::<Gauge<T>>().unwrap();
+                        assert_eq!(
+                            self.expected_value,
+                            gauge.data_points
+                                .iter()
+                                .map(|data_point| data_point.value)
+                                .sum()
+                        );
+
+                        if let Some(expected_attributes) = self.expected_attributes.as_ref() {
+                            gauge.data_points.iter().for_each(|data_point| {
                                 assert_eq!(expected_attributes, &data_point.attributes,)
                             });
                         }


### PR DESCRIPTION
## Motivation

The [opentelemetry](https://github.com/open-telemetry/opentelemetry-rust/blob/a7a47a745dfe9ded79ffb64722fc53847638d47a/examples/metrics-basic/src/main.rs#L112) crate actually supports `Gauge` metric behind `otel_unstable` feature.

## Solution

Extend the current implementation with the treatment for the new `Gauge` metric.

The tests are passing but i don't know if there are necessary other type of tests (at this point, the property `start_time` inside the `DataPoints` of the `Gauge` type are `None` in all the test, for example. L664 of tests/metrics_publishing.rs file).
