### PR TITLE
Fix example usage in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,10 +106,10 @@ tracing-subscriber = "0.3"
 
 ```console
 # Run a supported collector like jaeger in the background
-$ docker run -d -p6831:6831/udp -p6832:6832/udp -p16686:16686 jaegertracing/all-in-one:latest
+$ docker run -d -p4317:4317 -p16686:16686 jaegertracing/all-in-one:latest
 
 # Run example to produce spans (from parent examples directory)
-$ cargo run --example opentelemetry
+$ cargo run --example opentelemetry-otlp
 
 # View spans (see the image below)
 $ firefox http://localhost:16686/


### PR DESCRIPTION

## Motivation

Closes #126 

The example in readme was broken because it has been renamed.

## Solution

Changed the name of example to be run. I've also cleared up ports in the jaeger.

The example now outputs much less information than the example before, but that more compilcated example started using stdout instead.