### PR TITLE
deps: Bump to otel to version 0.23

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,8 +25,8 @@ default = ["tracing-log", "metrics"]
 metrics = ["opentelemetry/metrics","opentelemetry_sdk/metrics", "smallvec"]
 
 [dependencies]
-opentelemetry = { version = "0.22.0", default-features = false, features = ["trace"] }
-opentelemetry_sdk = { version = "0.22.0", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.23.0", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.23.0", default-features = false, features = ["trace"] }
 tracing = { version = "0.1.35", default-features = false, features = ["std"] }
 tracing-core = "0.1.28"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
@@ -42,12 +42,12 @@ smallvec = { version = "1.0", optional = true }
 [dev-dependencies]
 async-trait = "0.1.56"
 criterion = { version = "0.5.1", default-features = false, features = ["html_reports"] }
-opentelemetry = { version = "0.22.0", features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.22.0", default-features = false, features = ["trace", "rt-tokio"] }
-opentelemetry-jaeger = "0.21.0"
-opentelemetry-stdout = { version = "0.3.0", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.15.0", features = ["metrics"] }
-opentelemetry-semantic-conventions = "0.14.0"
+opentelemetry = { version = "0.23.0", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.23.0", default-features = false, features = ["trace", "rt-tokio"] }
+opentelemetry-jaeger = "0.22.0"
+opentelemetry-stdout = { version = "0.4.0", features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.16.0", features = ["metrics"] }
+opentelemetry-semantic-conventions = "0.15.0"
 futures-util = { version = "0.3.17", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/examples/opentelemetry-error.rs
+++ b/examples/opentelemetry-error.rs
@@ -1,5 +1,4 @@
 use std::{
-    borrow::Cow,
     error::Error as StdError,
     fmt::{Debug, Display},
     io::Write,
@@ -60,12 +59,9 @@ fn double_failable_work(fail: bool) -> Result<&'static str, Error> {
 fn main() -> Result<(), Box<dyn StdError + Send + Sync + 'static>> {
     let builder = sdk::trace::TracerProvider::builder().with_simple_exporter(WriterExporter);
     let provider = builder.build();
-    let tracer = provider.versioned_tracer(
-        "opentelemetry-write-exporter",
-        None::<Cow<'static, str>>,
-        None::<Cow<'static, str>>,
-        None,
-    );
+    let tracer = provider
+        .tracer_builder("opentelemetry-write-exporter")
+        .build();
     global::set_tracer_provider(provider);
 
     let opentelemetry = tracing_opentelemetry::layer().with_tracer(tracer);

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1022,7 +1022,7 @@ where
                 .span()
                 .span_context()
                 .clone();
-            let follows_link = otel::Link::new(follows_context, Vec::new());
+            let follows_link = otel::Link::with_context(follows_context);
             if let Some(ref mut links) = data.builder.links {
                 links.push(follows_link);
             } else {
@@ -1212,7 +1212,7 @@ fn thread_id_integer(id: thread::ThreadId) -> u64 {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use opentelemetry::trace::TraceFlags;
+    use opentelemetry::trace::{SpanContext, TraceFlags};
     use std::{
         collections::HashMap,
         error::Error,
@@ -1290,6 +1290,7 @@ mod tests {
         fn set_attribute(&mut self, _attribute: KeyValue) {}
         fn set_status(&mut self, _status: otel::Status) {}
         fn update_name<T: Into<Cow<'static, str>>>(&mut self, _new_name: T) {}
+        fn add_link(&mut self, _span_context: SpanContext, _attributes: Vec<KeyValue>) {}
         fn end_with_timestamp(&mut self, _timestamp: SystemTime) {}
     }
 

--- a/src/span_ext.rs
+++ b/src/span_ext.rs
@@ -162,7 +162,7 @@ impl OpenTelemetrySpanExt for tracing::Span {
                     get_context.with_context(subscriber, id, move |data, _tracer| {
                         if let Some(cx) = cx.take() {
                             let attr = att.take().unwrap_or_default();
-                            let follows_link = opentelemetry::trace::Link::new(cx, attr);
+                            let follows_link = opentelemetry::trace::Link::new(cx, attr, 0);
                             data.builder
                                 .links
                                 .get_or_insert_with(|| Vec::with_capacity(1))


### PR DESCRIPTION
## Motivation

Bump otel related crates to the latest version.

This PR will close the following PRs:

- https://github.com/tokio-rs/tracing-opentelemetry/pull/132
- https://github.com/tokio-rs/tracing-opentelemetry/pull/133
- https://github.com/tokio-rs/tracing-opentelemetry/pull/134
- https://github.com/tokio-rs/tracing-opentelemetry/pull/135
- https://github.com/tokio-rs/tracing-opentelemetry/pull/136
- https://github.com/tokio-rs/tracing-opentelemetry/pull/137

Also

- https://github.com/tokio-rs/tracing-opentelemetry/pull/139
- https://github.com/tokio-rs/tracing-opentelemetry/issues/141

## Solution

Bump version in crates and alter some API usage.