### PR TITLE
chore: Use 2021 edition instead

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ categories = [
 ]
 keywords = ["tracing", "opentelemetry", "jaeger", "zipkin", "async"]
 license = "MIT"
-edition = "2018"
+edition = "2021"
 rust-version = "1.65.0"
 
 [features]


### PR DESCRIPTION
## Motivation

Use 2021 edition instead to make it a bit new.

## Solution

As titled.