### PR TITLE
Clear cached sample_result in tracing::Span::set_parent()

### DIFF
--- a/src/span_ext.rs
+++ b/src/span_ext.rs
@@ -142,6 +142,9 @@ impl OpenTelemetrySpanExt for tracing::Span {
             if let Some(get_context) = subscriber.downcast_ref::<WithContext>() {
                 get_context.with_context(subscriber, id, move |data, _tracer| {
                     if let Some(cx) = cx.take() {
+                        // Clear latched sampling_result so it will recompute from
+                        // the new parent_cx after changing parents.
+                        data.builder.sampling_result = None;
                         data.parent_cx = cx;
                     }
                 });


### PR DESCRIPTION
## Motivation
Fixes https://github.com/tokio-rs/tracing-opentelemetry/issues/150
<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution
Clear cached `OtelData.builder.sample_result` in `tracing::Span::set_parent()`
so it is recomputed again after the parent changes.

TODO: needs a repro that we can turn into a test.
