### PR TITLE
Upgrade to opentelemetry 0.25

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# [Unreleased]
+
+### Breaking Changes
+
+- Upgrade to opentelemetry 0.25. Refer to the upstream
+  [changelog](https://github.com/open-telemetry/opentelemetry-rust/releases/tag/opentelemetry-0.25.0)
+  for more information.
+
 # 0.25.0 (July 21, 2024)
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ metrics = ["opentelemetry/metrics","opentelemetry_sdk/metrics", "smallvec"]
 metrics_gauge_unstable = ["opentelemetry/otel_unstable"]
 
 [dependencies]
-opentelemetry = { version = "0.24", default-features = false, features = ["trace"] }
-opentelemetry_sdk = { version = "0.24.1", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.25", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.25.0", default-features = false, features = ["trace"] }
 tracing = { version = "0.1.35", default-features = false, features = ["std"] }
 tracing-core = "0.1.28"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
@@ -41,11 +41,11 @@ smallvec = { version = "1.0", optional = true }
 [dev-dependencies]
 async-trait = "0.1.56"
 criterion = { version = "0.5.1", default-features = false, features = ["html_reports"] }
-opentelemetry = { version = "0.24", features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.24", default-features = false, features = ["trace", "rt-tokio"] }
-opentelemetry-stdout = { version = "0.5", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.17", features = ["metrics"] }
-opentelemetry-semantic-conventions = "0.16"
+opentelemetry = { version = "0.25", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.25", default-features = false, features = ["trace", "rt-tokio"] }
+opentelemetry-stdout = { version = "0.25", features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.25", features = ["metrics"] }
+opentelemetry-semantic-conventions = "0.25"
 futures-util = { version = "0.3.17", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.25.0"
+version = "0.26.0"
 description = "OpenTelemetry integration for tracing"
 homepage = "https://github.com/tokio-rs/tracing-opentelemetry"
 repository = "https://github.com/tokio-rs/tracing-opentelemetry"

--- a/examples/opentelemetry-otlp.rs
+++ b/examples/opentelemetry-otlp.rs
@@ -9,7 +9,7 @@ use opentelemetry_sdk::{
     Resource,
 };
 use opentelemetry_semantic_conventions::{
-    resource::{DEPLOYMENT_ENVIRONMENT, SERVICE_NAME, SERVICE_VERSION},
+    resource::{DEPLOYMENT_ENVIRONMENT_NAME, SERVICE_NAME, SERVICE_VERSION},
     SCHEMA_URL,
 };
 use tracing_core::Level;
@@ -22,7 +22,7 @@ fn resource() -> Resource {
         [
             KeyValue::new(SERVICE_NAME, env!("CARGO_PKG_NAME")),
             KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
-            KeyValue::new(DEPLOYMENT_ENVIRONMENT, "develop"),
+            KeyValue::new(DEPLOYMENT_ENVIRONMENT_NAME, "develop"),
         ],
         SCHEMA_URL,
     )

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -646,7 +646,7 @@ where
     /// exceptions][conv].
     ///
     /// * Only events without a message field (unnamed events) and at least one field with the name error
-    /// are considered for mapping.
+    ///   are considered for mapping.
     ///
     /// By default, these events are mapped.
     ///
@@ -1693,7 +1693,7 @@ mod tests {
             let context = tracing_error::SpanTrace::capture();
 
             // This can cause a deadlock if `on_record` locks extensions while attributes are visited
-            span.record("exception", &tracing::field::debug(&context));
+            span.record("exception", tracing::field::debug(&context));
             // This can cause a deadlock if `on_event` locks extensions while the event is visited
             tracing::info!(exception = &tracing::field::debug(&context), "hello");
         });

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@
 //! special fields are:
 //!
 //! * `otel.name`: Override the span name sent to OpenTelemetry exporters.
-//! Setting this field is useful if you want to display non-static information
-//! in your span name.
+//!    Setting this field is useful if you want to display non-static information
+//!    in your span name.
 //! * `otel.kind`: Set the span kind to one of the supported OpenTelemetry [span kinds].
 //! * `otel.status_code`: Set the span status code to one of the supported OpenTelemetry [span status codes].
 //! * `otel.status_message`: Set the span status message.

--- a/tests/metrics_publishing.rs
+++ b/tests/metrics_publishing.rs
@@ -6,7 +6,7 @@ use opentelemetry_sdk::{
             AggregationSelector, DefaultAggregationSelector, DefaultTemporalitySelector,
             MetricReader, TemporalitySelector,
         },
-        AttributeSet, InstrumentKind, ManualReader, MeterProviderBuilder, SdkMeterProvider,
+        InstrumentKind, ManualReader, MeterProviderBuilder, SdkMeterProvider,
     },
     Resource,
 };
@@ -195,16 +195,13 @@ async fn u64_counter_with_attributes_is_exported() {
         "hello_world".to_string(),
         InstrumentKind::Counter,
         1_u64,
-        Some(AttributeSet::from(
-            [
-                KeyValue::new("u64_key_1", 1_i64),
-                KeyValue::new("i64_key_1", 2_i64),
-                KeyValue::new("f64_key_1", 3_f64),
-                KeyValue::new("str_key_1", "foo"),
-                KeyValue::new("bool_key_1", true),
-            ]
-            .as_slice(),
-        )),
+        Some(vec![
+            KeyValue::new("u64_key_1", 1_i64),
+            KeyValue::new("i64_key_1", 2_i64),
+            KeyValue::new("f64_key_1", 3_f64),
+            KeyValue::new("str_key_1", "foo"),
+            KeyValue::new("bool_key_1", true),
+        ]),
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -227,16 +224,13 @@ async fn f64_counter_with_attributes_is_exported() {
         "hello_world".to_string(),
         InstrumentKind::Counter,
         1_f64,
-        Some(AttributeSet::from(
-            [
-                KeyValue::new("u64_key_1", 1_i64),
-                KeyValue::new("i64_key_1", 2_i64),
-                KeyValue::new("f64_key_1", 3_f64),
-                KeyValue::new("str_key_1", "foo"),
-                KeyValue::new("bool_key_1", true),
-            ]
-            .as_slice(),
-        )),
+        Some(vec![
+            KeyValue::new("u64_key_1", 1_i64),
+            KeyValue::new("i64_key_1", 2_i64),
+            KeyValue::new("f64_key_1", 3_f64),
+            KeyValue::new("str_key_1", "foo"),
+            KeyValue::new("bool_key_1", true),
+        ]),
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -259,16 +253,13 @@ async fn i64_up_down_counter_with_attributes_is_exported() {
         "hello_world".to_string(),
         InstrumentKind::UpDownCounter,
         -1_i64,
-        Some(AttributeSet::from(
-            [
-                KeyValue::new("u64_key_1", 1_i64),
-                KeyValue::new("i64_key_1", 2_i64),
-                KeyValue::new("f64_key_1", 3_f64),
-                KeyValue::new("str_key_1", "foo"),
-                KeyValue::new("bool_key_1", true),
-            ]
-            .as_slice(),
-        )),
+        Some(vec![
+            KeyValue::new("u64_key_1", 1_i64),
+            KeyValue::new("i64_key_1", 2_i64),
+            KeyValue::new("f64_key_1", 3_f64),
+            KeyValue::new("str_key_1", "foo"),
+            KeyValue::new("bool_key_1", true),
+        ]),
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -291,16 +282,13 @@ async fn f64_up_down_counter_with_attributes_is_exported() {
         "hello_world".to_string(),
         InstrumentKind::UpDownCounter,
         -1_f64,
-        Some(AttributeSet::from(
-            [
-                KeyValue::new("u64_key_1", 1_i64),
-                KeyValue::new("i64_key_1", 2_i64),
-                KeyValue::new("f64_key_1", 3_f64),
-                KeyValue::new("str_key_1", "foo"),
-                KeyValue::new("bool_key_1", true),
-            ]
-            .as_slice(),
-        )),
+        Some(vec![
+            KeyValue::new("u64_key_1", 1_i64),
+            KeyValue::new("i64_key_1", 2_i64),
+            KeyValue::new("f64_key_1", 3_f64),
+            KeyValue::new("str_key_1", "foo"),
+            KeyValue::new("bool_key_1", true),
+        ]),
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -324,16 +312,13 @@ async fn f64_gauge_with_attributes_is_exported() {
         "hello_world".to_string(),
         InstrumentKind::Gauge,
         1_f64,
-        Some(AttributeSet::from(
-            [
-                KeyValue::new("u64_key_1", 1_i64),
-                KeyValue::new("i64_key_1", 2_i64),
-                KeyValue::new("f64_key_1", 3_f64),
-                KeyValue::new("str_key_1", "foo"),
-                KeyValue::new("bool_key_1", true),
-            ]
-            .as_slice(),
-        )),
+        Some(vec![
+            KeyValue::new("u64_key_1", 1_i64),
+            KeyValue::new("i64_key_1", 2_i64),
+            KeyValue::new("f64_key_1", 3_f64),
+            KeyValue::new("str_key_1", "foo"),
+            KeyValue::new("bool_key_1", true),
+        ]),
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -357,16 +342,13 @@ async fn u64_gauge_with_attributes_is_exported() {
         "hello_world".to_string(),
         InstrumentKind::Gauge,
         1_u64,
-        Some(AttributeSet::from(
-            [
-                KeyValue::new("u64_key_1", 1_i64),
-                KeyValue::new("i64_key_1", 2_i64),
-                KeyValue::new("f64_key_1", 3_f64),
-                KeyValue::new("str_key_1", "foo"),
-                KeyValue::new("bool_key_1", true),
-            ]
-            .as_slice(),
-        )),
+        Some(vec![
+            KeyValue::new("u64_key_1", 1_i64),
+            KeyValue::new("i64_key_1", 2_i64),
+            KeyValue::new("f64_key_1", 3_f64),
+            KeyValue::new("str_key_1", "foo"),
+            KeyValue::new("bool_key_1", true),
+        ]),
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -390,16 +372,13 @@ async fn i64_gauge_with_attributes_is_exported() {
         "hello_world".to_string(),
         InstrumentKind::Gauge,
         1_i64,
-        Some(AttributeSet::from(
-            [
-                KeyValue::new("u64_key_1", 1_i64),
-                KeyValue::new("i64_key_1", 2_i64),
-                KeyValue::new("f64_key_1", 3_f64),
-                KeyValue::new("str_key_1", "foo"),
-                KeyValue::new("bool_key_1", true),
-            ]
-            .as_slice(),
-        )),
+        Some(vec![
+            KeyValue::new("u64_key_1", 1_i64),
+            KeyValue::new("i64_key_1", 2_i64),
+            KeyValue::new("f64_key_1", 3_f64),
+            KeyValue::new("str_key_1", "foo"),
+            KeyValue::new("bool_key_1", true),
+        ]),
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -422,16 +401,13 @@ async fn u64_histogram_with_attributes_is_exported() {
         "hello_world".to_string(),
         InstrumentKind::Histogram,
         1_u64,
-        Some(AttributeSet::from(
-            [
-                KeyValue::new("u64_key_1", 1_i64),
-                KeyValue::new("i64_key_1", 2_i64),
-                KeyValue::new("f64_key_1", 3_f64),
-                KeyValue::new("str_key_1", "foo"),
-                KeyValue::new("bool_key_1", true),
-            ]
-            .as_slice(),
-        )),
+        Some(vec![
+            KeyValue::new("u64_key_1", 1_i64),
+            KeyValue::new("i64_key_1", 2_i64),
+            KeyValue::new("f64_key_1", 3_f64),
+            KeyValue::new("str_key_1", "foo"),
+            KeyValue::new("bool_key_1", true),
+        ]),
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -454,16 +430,13 @@ async fn f64_histogram_with_attributes_is_exported() {
         "hello_world".to_string(),
         InstrumentKind::Histogram,
         1_f64,
-        Some(AttributeSet::from(
-            [
-                KeyValue::new("u64_key_1", 1_i64),
-                KeyValue::new("i64_key_1", 2_i64),
-                KeyValue::new("f64_key_1", 3_f64),
-                KeyValue::new("str_key_1", "foo"),
-                KeyValue::new("bool_key_1", true),
-            ]
-            .as_slice(),
-        )),
+        Some(vec![
+            KeyValue::new("u64_key_1", 1_i64),
+            KeyValue::new("i64_key_1", 2_i64),
+            KeyValue::new("f64_key_1", 3_f64),
+            KeyValue::new("str_key_1", "foo"),
+            KeyValue::new("bool_key_1", true),
+        ]),
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -486,9 +459,7 @@ async fn display_attribute_is_exported() {
         "hello_world".to_string(),
         InstrumentKind::Counter,
         1_u64,
-        Some(AttributeSet::from(
-            [KeyValue::new("display_key_1", "display: foo")].as_slice(),
-        )),
+        Some(vec![KeyValue::new("display_key_1", "display: foo")]),
     );
 
     struct DisplayAttribute(String);
@@ -517,9 +488,7 @@ async fn debug_attribute_is_exported() {
         "hello_world".to_string(),
         InstrumentKind::Counter,
         1_u64,
-        Some(AttributeSet::from(
-            [KeyValue::new("debug_key_1", "debug: foo")].as_slice(),
-        )),
+        Some(vec![KeyValue::new("debug_key_1", "debug: foo")]),
     );
 
     struct DebugAttribute(String);
@@ -546,7 +515,7 @@ fn init_subscriber<T>(
     expected_metric_name: String,
     expected_instrument_kind: InstrumentKind,
     expected_value: T,
-    expected_attributes: Option<AttributeSet>,
+    expected_attributes: Option<Vec<KeyValue>>,
 ) -> (impl Subscriber + 'static, TestExporter<T>) {
     let reader = ManualReader::builder()
         .with_aggregation_selector(DefaultAggregationSelector::new())
@@ -563,12 +532,7 @@ fn init_subscriber<T>(
         expected_metric_name,
         expected_instrument_kind,
         expected_value,
-        expected_attributes: expected_attributes.map(|attrs| {
-            attrs
-                .iter()
-                .map(|(k, v)| KeyValue::new(k.clone(), v.clone()))
-                .collect()
-        }),
+        expected_attributes,
         reader,
         _meter_provider: provider.clone(),
     };
@@ -659,7 +623,10 @@ where
 
                         if let Some(expected_attributes) = self.expected_attributes.as_ref() {
                             sum.data_points.iter().for_each(|data_point| {
-                                assert_eq!(expected_attributes, &data_point.attributes)
+                                assert!(compare_attributes(
+                                    expected_attributes,
+                                    &data_point.attributes,
+                                ))
                             });
                         }
                     }
@@ -677,7 +644,10 @@ where
 
                         if let Some(expected_attributes) = self.expected_attributes.as_ref() {
                             gauge.data_points.iter().for_each(|data_point| {
-                                assert_eq!(expected_attributes, &data_point.attributes)
+                                assert!(compare_attributes(
+                                    expected_attributes,
+                                    &data_point.attributes,
+                                ))
                             });
                         }
                     }
@@ -689,7 +659,10 @@ where
                         assert_eq!(histogram_data.sum, self.expected_value);
 
                         if let Some(expected_attributes) = self.expected_attributes.as_ref() {
-                            assert_eq!(expected_attributes, &histogram_data.attributes);
+                            assert!(compare_attributes(
+                                expected_attributes,
+                                &histogram_data.attributes
+                            ))
                         }
                     }
                     unexpected => {
@@ -701,4 +674,17 @@ where
 
         Ok(())
     }
+}
+
+// After sorting the KeyValue vec, compare them.
+// Return true if they are equal.
+#[allow(clippy::ptr_arg)]
+fn compare_attributes(expected: &Vec<KeyValue>, actual: &Vec<KeyValue>) -> bool {
+    let mut expected = expected.clone();
+    let mut actual = actual.clone();
+
+    expected.sort();
+    actual.sort();
+
+    expected == actual
 }


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing-opentelemetry/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

Update opentelemetry depencencies to 0.25
https://github.com/open-telemetry/opentelemetry-rust/releases/tag/opentelemetry-0.25.0

From version 0.25, OpenTelemetry started using a unified version across all crates.
https://github.com/open-telemetry/opentelemetry-rust/issues/2084

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

* Upgrade opentelemetry deps to 0.25
* Remove `AttributeSet` from tests
   * https://github.com/open-telemetry/opentelemetry-rust/pull/2045
* Rename deprecated `deployment.environment` semantic conv to `deployment.environment.name`
  * https://opentelemetry.io/docs/specs/semconv/attributes-registry/enduser/
