### PR TITLE
fix: add support for exporting opentelemetry logs_level_enabled feature

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,8 @@ rust-version = "1.65.0"
 
 [features]
 default = ["tracing-log", "metrics"]
+# Enables support for exporting OpenTelemetry logs_level_enabled
+logs_level_enabled = ["opentelemetry/logs_level_enabled","opentelemetry_sdk/logs_level_enabled"]
 # Enables support for exporting OpenTelemetry metrics
 metrics = ["opentelemetry/metrics","opentelemetry_sdk/metrics", "smallvec"]
 # Enables experimental support for OpenTelemetry gauge metrics


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing-opentelemetry/blob/master/CONTRIBUTING.md
-->

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

When building `tracing-opentelemetry` and the opentelemetry crate with `logs_level_enabled` feature on a crate, it fails to build on `opentelemetry>=0.25.0`.

It's because the `opentelemetry::logs::Logger` trait contains a fn `event_enabled` which is only enabled with the `logs_level_enabled` feature.

See also:
https://github.com/open-telemetry/opentelemetry-rust/blame/3976f3d4867d564c98a566df83eb59e31c653b84/opentelemetry-sdk/src/logs/log_emitter.rs#L270-L284

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Add support for exporting opentelemetry logs_level_enabled feature
