### PR TITLE
Added notes to README to clarify version compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,8 @@ The crate provides the following types:
 
 Note that version numbers for this crate are **not** synchronized with the
 various OpenTelemetry crates, despite having similar version numbers. For
-discussion, see issue #170.
+discussion, see
+[issue #170](https://github.com/tokio-rs/tracing-opentelemetry/issues/170).
 
 Importantly, `tracing-opentelemetry` 0.26 is compatible with **0.25** of the
 OpenTelemetry crates, as their 0.26 has breaking changes that have not yet (as

--- a/README.md
+++ b/README.md
@@ -54,6 +54,17 @@ The crate provides the following types:
 
 [msrv]: #supported-rust-versions
 
+## Compatibility with OpenTelemetry crates
+
+Note that version numbers for this crate are **not** synchronized with the
+various OpenTelemetry crates, despite having similar version numbers. For
+discussion, see issue #170.
+
+Importantly, `tracing-opentelemetry` 0.26 is compatible with **0.25** of the
+OpenTelemetry crates, as their 0.26 has breaking changes that have not yet (as
+of 2024-10-08) been addressed in this crate.
+
+
 ## Examples
 
 ### Basic Usage
@@ -94,15 +105,35 @@ fn main() {
 `Cargo.toml`
 ```toml
 [dependencies]
-opentelemetry = "0.21"
-opentelemetry_sdk = "0.21"
-opentelemetry-stdout = { version = "0.2.0", features = ["trace"] }
+opentelemetry = "0.25"
+opentelemetry_sdk = "0.25"
+opentelemetry-stdout = { version = "0.25", features = ["trace"] }
 tracing = "0.1"
-tracing-opentelemetry = "0.22"
+tracing-opentelemetry = "0.26"
 tracing-subscriber = "0.3"
 ```
 
 ### Visualization example
+
+See [`opentelemetry-otlp.rs`](examples/opentelemetry-otlp.rs) in the
+[`examples`](examples) directory. To use this code in your own project, your
+`Cargo.toml` should include the following:
+
+```toml
+[dependencies]
+tokio = { version = "1", features = ["full"] }
+opentelemetry = "0.25"
+opentelemetry_sdk = { version = "0.25", features = ["rt-tokio"] }
+opentelemetry-stdout = "0.25"
+opentelemetry-otlp = "0.25"
+opentelemetry-semantic-conventions = "0.25"
+tracing = "0.1"
+tracing-core = "0.1"
+tracing-opentelemetry = "0.26"
+tracing-subscriber = "0.3"
+```
+
+To run the example from this repository:
 
 ```console
 # Run a supported collector like jaeger in the background


### PR DESCRIPTION
## Motivation

Version compatibility with the OpenTelemetry crates is potentially confusing to new adopters, as the current version of this crate is 0.26, but it is **not** compatible with 0.26 of the OpenTelemetry crates. A naive developer might simply set the versions for all the dependencies to 0.26 in their own project, which results in some very confusing compiler errors that take some research to figure out (ask me how I know!).

## Solution

I added a new section titled "Compatibility with OpenTelemetry crates" just below the "Overview" section. It includes a link to the discussion in #170 as well as a special note about the current 0.26 versus 0.25 situation.

While I was at it, I updated the dependencies in the `Cargo.toml` example in the "Basic Usage" section and ensured that the example code still works with the updated versions.

I also added to the "Visualization example" section, including a link to the `opentelemetry-otlp.rs` example and a minimum `Cargo.toml` example for using that code in a separate project. I simplified the dependencies there to include only the minimum features necessary for the example to work.