### PR TITLE
Fix the example installing `OpenTelemetryLayer` into a global subscriber

### DIFF
--- a/examples/opentelemetry-otlp.rs
+++ b/examples/opentelemetry-otlp.rs
@@ -85,6 +85,13 @@ fn init_tracing_subscriber() -> OtelGuard {
     let tracer = tracer_provider.tracer("tracing-otel-subscriber");
 
     tracing_subscriber::registry()
+        // The global level filter prevents the exporter network stack
+        // from reentering the globally installed OpenTelemetryLayer with
+        // its own spans while exporting, as the libraries should not use
+        // tracing levels below DEBUG. If the OpenTelemetry layer needs to
+        // trace spans and events with higher verbosity levels, consider using
+        // per-layer filtering to target the telemetry layer specifically,
+        // e.g. by target matching.
         .with(tracing_subscriber::filter::LevelFilter::from_level(
             Level::INFO,
         ))

--- a/tests/batch_global_subscriber.rs
+++ b/tests/batch_global_subscriber.rs
@@ -1,0 +1,65 @@
+use futures_util::future::BoxFuture;
+use opentelemetry::trace::TracerProvider as _;
+use opentelemetry_sdk::{
+    export::trace::{ExportResult, SpanData, SpanExporter},
+    runtime,
+    trace::TracerProvider,
+};
+use tokio::runtime::Runtime;
+use tracing::{info_span, subscriber, Level, Subscriber};
+use tracing_opentelemetry::layer;
+use tracing_subscriber::filter;
+use tracing_subscriber::prelude::*;
+
+use std::sync::{Arc, Mutex};
+
+#[derive(Clone, Debug, Default)]
+struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
+
+impl SpanExporter for TestExporter {
+    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+        let spans = self.0.clone();
+        Box::pin(async move {
+            if let Ok(mut inner) = spans.lock() {
+                inner.append(&mut batch);
+            }
+            Ok(())
+        })
+    }
+}
+
+fn test_tracer(runtime: &Runtime) -> (TracerProvider, TestExporter, impl Subscriber) {
+    let _guard = runtime.enter();
+
+    let exporter = TestExporter::default();
+    let provider = TracerProvider::builder()
+        .with_batch_exporter(exporter.clone(), runtime::Tokio)
+        .build();
+    let tracer = provider.tracer("test");
+
+    let subscriber = tracing_subscriber::registry().with(
+        layer()
+            .with_tracer(tracer)
+            .with_filter(filter::Targets::new().with_target("test_telemetry", Level::INFO)),
+    );
+
+    (provider, exporter, subscriber)
+}
+
+#[test]
+fn test_global_default() {
+    let rt = Runtime::new().unwrap();
+    let (provider, exporter, subscriber) = test_tracer(&rt);
+
+    subscriber::set_global_default(subscriber).unwrap();
+
+    for _ in 0..1000 {
+        let _span = info_span!(target: "test_telemetry", "test_span").entered();
+    }
+
+    // Should flush all batched telemetry spans
+    provider.shutdown().unwrap();
+
+    let spans = exporter.0.lock().unwrap();
+    assert_eq!(spans.len(), 1000);
+}


### PR DESCRIPTION
Fixes #159

## Motivation

Use of `global::shutdown_tracer_provider` has regressed since opentelemetry 0.23.

## Solution

Change the opentelemtry-otlp example to call `shutdown` on the `TracingProvider` available in scope.

Also added an integration test to verify the export behavior is as expected.
