### PR TITLE
chore: update opentelemetry dependencies to 0.27.0

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,7 +80,7 @@ jobs:
     - run: cargo hack check --feature-powerset --no-dev-deps
 
   check-msrv:
-    # Run `cargo check` on our minimum supported Rust version (1.60.0). This
+    # Run `cargo check` on our minimum supported Rust version (1.70.0). This
     # checks with minimal versions; maximal versions are checked above.
     name: "cargo check (+MSRV -Zminimal-versions)"
     needs: check
@@ -88,7 +88,7 @@ jobs:
     strategy:
       matrix:
         toolchain:
-        - 1.65.0
+        - 1.70.0
         - stable
     steps:
     - uses: actions/checkout@v4

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ metrics = ["opentelemetry/metrics","opentelemetry_sdk/metrics", "smallvec"]
 metrics_gauge_unstable = ["opentelemetry/otel_unstable"]
 
 [dependencies]
-opentelemetry = { version = "0.26", default-features = false, features = ["trace"] }
-opentelemetry_sdk = { version = "0.26", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.27.0", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.27.0", default-features = false, features = ["trace"] }
 tracing = { version = "0.1.35", default-features = false, features = ["std"] }
 tracing-core = "0.1.28"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
@@ -41,11 +41,11 @@ smallvec = { version = "1.0", optional = true }
 [dev-dependencies]
 async-trait = "0.1.56"
 criterion = { version = "0.5.1", default-features = false, features = ["html_reports"] }
-opentelemetry = { version = "0.26", features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.26", default-features = false, features = ["trace", "rt-tokio"] }
-opentelemetry-stdout = { version = "0.26", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.26", features = ["metrics"] }
-opentelemetry-semantic-conventions = { version = "0.26", features = ["semconv_experimental"] }
+opentelemetry = { version = "0.27.0", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.27.0", default-features = false, features = ["trace", "rt-tokio"] }
+opentelemetry-stdout = { version = "0.27.0", features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.27.0", features = ["metrics"] }
+opentelemetry-semantic-conventions = { version = "0.27.0", features = ["semconv_experimental"] }
 futures-util = { version = "0.3.17", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ categories = [
 keywords = ["tracing", "opentelemetry", "jaeger", "zipkin", "async"]
 license = "MIT"
 edition = "2021"
-rust-version = "1.65.0"
+rust-version = "1.70.0"
 
 [features]
 default = ["tracing-log", "metrics"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tracing-opentelemetry"
-version = "0.27.0"
+version = "0.28.0"
 description = "OpenTelemetry integration for tracing"
 homepage = "https://github.com/tokio-rs/tracing-opentelemetry"
 repository = "https://github.com/tokio-rs/tracing-opentelemetry"

--- a/benches/metrics.rs
+++ b/benches/metrics.rs
@@ -1,9 +1,34 @@
 use criterion::{criterion_group, criterion_main, Criterion};
-use opentelemetry::metrics::noop::NoopMeterProvider;
 #[cfg(not(target_os = "windows"))]
 use pprof::criterion::{Output, PProfProfiler};
 use tracing_opentelemetry::MetricsLayer;
 use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
+
+// OpenTelemetry crate no longer publishes their NoopMeterProvider,
+// so we just implement our own here.
+mod noop {
+    use opentelemetry::metrics::{InstrumentProvider, Meter, MeterProvider};
+
+    #[derive(Default)]
+    pub struct NoopMeterProvider {
+        _private: (),
+    }
+
+    impl MeterProvider for NoopMeterProvider {
+        fn meter_with_scope(&self, _: opentelemetry::InstrumentationScope) -> Meter {
+            Meter::new(std::sync::Arc::new(NoopMeter::default()))
+        }
+    }
+
+    #[derive(Default)]
+    pub struct NoopMeter {
+        _private: (),
+    }
+
+    impl InstrumentProvider for NoopMeter {}
+}
+
+use noop::*;
 
 fn metrics_events(c: &mut Criterion) {
     let mut group = c.benchmark_group("otel_metrics_events");
@@ -18,7 +43,7 @@ fn metrics_events(c: &mut Criterion) {
 
     {
         let _subscriber = tracing_subscriber::registry()
-            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .with(MetricsLayer::new(NoopMeterProvider::default()))
             .set_default();
         group.bench_function("metrics_events_0_attr_0", |b| {
             b.iter(|| {
@@ -29,7 +54,7 @@ fn metrics_events(c: &mut Criterion) {
 
     {
         let _subscriber = tracing_subscriber::registry()
-            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .with(MetricsLayer::new(NoopMeterProvider::default()))
             .set_default();
         group.bench_function("metrics_events_1_attr_0", |b| {
             b.iter(|| {
@@ -40,7 +65,7 @@ fn metrics_events(c: &mut Criterion) {
 
     {
         let _subscriber = tracing_subscriber::registry()
-            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .with(MetricsLayer::new(NoopMeterProvider::default()))
             .set_default();
         group.bench_function("metrics_events_2_attr_0", |b| {
             b.iter(|| {
@@ -51,7 +76,7 @@ fn metrics_events(c: &mut Criterion) {
 
     {
         let _subscriber = tracing_subscriber::registry()
-            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .with(MetricsLayer::new(NoopMeterProvider::default()))
             .set_default();
         group.bench_function("metrics_events_4_attr_0", |b| {
             b.iter(|| {
@@ -68,7 +93,7 @@ fn metrics_events(c: &mut Criterion) {
 
     {
         let _subscriber = tracing_subscriber::registry()
-            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .with(MetricsLayer::new(NoopMeterProvider::default()))
             .set_default();
         group.bench_function("metrics_events_8_attr_0", |b| {
             b.iter(|| {
@@ -89,7 +114,7 @@ fn metrics_events(c: &mut Criterion) {
 
     {
         let _subscriber = tracing_subscriber::registry()
-            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .with(MetricsLayer::new(NoopMeterProvider::default()))
             .set_default();
         group.bench_function("metrics_events_1_attr_1", |b| {
             b.iter(|| {
@@ -100,7 +125,7 @@ fn metrics_events(c: &mut Criterion) {
 
     {
         let _subscriber = tracing_subscriber::registry()
-            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .with(MetricsLayer::new(NoopMeterProvider::default()))
             .set_default();
         group.bench_function("metrics_events_1_attr_2", |b| {
             b.iter(|| {
@@ -116,7 +141,7 @@ fn metrics_events(c: &mut Criterion) {
 
     {
         let _subscriber = tracing_subscriber::registry()
-            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .with(MetricsLayer::new(NoopMeterProvider::default()))
             .set_default();
         group.bench_function("metrics_events_1_attr_4", |b| {
             b.iter(|| {
@@ -134,7 +159,7 @@ fn metrics_events(c: &mut Criterion) {
 
     {
         let _subscriber = tracing_subscriber::registry()
-            .with(MetricsLayer::new(NoopMeterProvider::new()))
+            .with(MetricsLayer::new(NoopMeterProvider::default()))
             .set_default();
         group.bench_function("metrics_events_1_attr_8", |b| {
             b.iter(|| {

--- a/examples/opentelemetry-error.rs
+++ b/examples/opentelemetry-error.rs
@@ -6,8 +6,8 @@ use std::{
     time::{Duration, SystemTime},
 };
 
-use opentelemetry::{global, trace::TracerProvider};
-
+use opentelemetry::global;
+use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::{
     self as sdk,
     export::trace::{ExportResult, SpanExporter},
@@ -59,9 +59,8 @@ fn double_failable_work(fail: bool) -> Result<&'static str, Error> {
 fn main() -> Result<(), Box<dyn StdError + Send + Sync + 'static>> {
     let builder = sdk::trace::TracerProvider::builder().with_simple_exporter(WriterExporter);
     let provider = builder.build();
-    let tracer = provider
-        .tracer_builder("opentelemetry-write-exporter")
-        .build();
+    let tracer = provider.tracer("opentelemetry-write-exporter");
+
     global::set_tracer_provider(provider);
 
     let opentelemetry = tracing_opentelemetry::layer().with_tracer(tracer);

--- a/examples/opentelemetry-otlp.rs
+++ b/examples/opentelemetry-otlp.rs
@@ -1,11 +1,8 @@
-use opentelemetry::{global, trace::TracerProvider, Key, KeyValue};
+use opentelemetry::{global, trace::TracerProvider as _, KeyValue};
 use opentelemetry_sdk::{
-    metrics::{
-        reader::DefaultTemporalitySelector, Aggregation, Instrument, MeterProviderBuilder,
-        PeriodicReader, SdkMeterProvider, Stream,
-    },
+    metrics::{MeterProviderBuilder, PeriodicReader, SdkMeterProvider},
     runtime,
-    trace::{BatchConfig, RandomIdGenerator, Sampler, Tracer},
+    trace::{RandomIdGenerator, Sampler, Tracer, TracerProvider},
     Resource,
 };
 use opentelemetry_semantic_conventions::{
@@ -30,9 +27,10 @@ fn resource() -> Resource {
 
 // Construct MeterProvider for MetricsLayer
 fn init_meter_provider() -> SdkMeterProvider {
-    let exporter = opentelemetry_otlp::new_exporter()
-        .tonic()
-        .build_metrics_exporter(Box::new(DefaultTemporalitySelector::new()))
+    let exporter = opentelemetry_otlp::MetricExporter::builder()
+        .with_tonic()
+        .with_temporality(opentelemetry_sdk::metrics::Temporality::default())
+        .build()
         .unwrap();
 
     let reader = PeriodicReader::builder(exporter, runtime::Tokio)
@@ -41,46 +39,15 @@ fn init_meter_provider() -> SdkMeterProvider {
 
     // For debugging in development
     let stdout_reader = PeriodicReader::builder(
-        opentelemetry_stdout::MetricsExporter::default(),
+        opentelemetry_stdout::MetricExporter::default(),
         runtime::Tokio,
     )
     .build();
-
-    // Rename foo metrics to foo_named and drop key_2 attribute
-    let view_foo = |instrument: &Instrument| -> Option<Stream> {
-        if instrument.name == "foo" {
-            Some(
-                Stream::new()
-                    .name("foo_named")
-                    .allowed_attribute_keys([Key::from("key_1")]),
-            )
-        } else {
-            None
-        }
-    };
-
-    // Set Custom histogram boundaries for baz metrics
-    let view_baz = |instrument: &Instrument| -> Option<Stream> {
-        if instrument.name == "baz" {
-            Some(
-                Stream::new()
-                    .name("baz")
-                    .aggregation(Aggregation::ExplicitBucketHistogram {
-                        boundaries: vec![0.0, 2.0, 4.0, 8.0, 16.0, 32.0, 64.0],
-                        record_min_max: true,
-                    }),
-            )
-        } else {
-            None
-        }
-    };
 
     let meter_provider = MeterProviderBuilder::default()
         .with_resource(resource())
         .with_reader(reader)
         .with_reader(stdout_reader)
-        .with_view(view_foo)
-        .with_view(view_baz)
         .build();
 
     global::set_meter_provider(meter_provider.clone());
@@ -90,9 +57,13 @@ fn init_meter_provider() -> SdkMeterProvider {
 
 // Construct Tracer for OpenTelemetryLayer
 fn init_tracer() -> Tracer {
-    let provider = opentelemetry_otlp::new_pipeline()
-        .tracing()
-        .with_trace_config(
+    let exporter = opentelemetry_otlp::SpanExporter::builder()
+        .with_tonic()
+        .build()
+        .unwrap();
+
+    let provider = TracerProvider::builder()
+        .with_config(
             opentelemetry_sdk::trace::Config::default()
                 // Customize sampling strategy
                 .with_sampler(Sampler::ParentBased(Box::new(Sampler::TraceIdRatioBased(
@@ -102,10 +73,8 @@ fn init_tracer() -> Tracer {
                 .with_id_generator(RandomIdGenerator::default())
                 .with_resource(resource()),
         )
-        .with_batch_config(BatchConfig::default())
-        .with_exporter(opentelemetry_otlp::new_exporter().tonic())
-        .install_batch(runtime::Tokio)
-        .unwrap();
+        .with_batch_exporter(exporter, runtime::Tokio)
+        .build();
 
     global::set_tracer_provider(provider.clone());
     provider.tracer("tracing-otel-subscriber")

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -536,17 +536,19 @@ where
     /// ```no_run
     /// use tracing_opentelemetry::OpenTelemetryLayer;
     /// use tracing_subscriber::layer::SubscriberExt;
-    /// use opentelemetry::trace::TracerProvider;
+    /// use opentelemetry::trace::TracerProvider as _;
     /// use tracing_subscriber::Registry;
     ///
     /// // Create an OTLP pipeline exporter for a `trace_demo` service.
     ///
-    /// let otlp_exporter = opentelemetry_otlp::new_exporter().tonic();
-    /// let tracer = opentelemetry_otlp::new_pipeline()
-    ///     .tracing()
-    ///     .with_exporter(otlp_exporter)
-    ///     .install_simple()
-    ///     .unwrap()
+    /// let otlp_exporter = opentelemetry_otlp::SpanExporter::builder()
+    ///     .with_tonic()
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// let tracer = opentelemetry_sdk::trace::TracerProvider::builder()
+    ///     .with_simple_exporter(otlp_exporter)
+    ///     .build()
     ///     .tracer("trace_demo");
     ///
     /// // Create a layer with the configured tracer
@@ -591,12 +593,14 @@ where
     ///
     /// // Create an OTLP pipeline exporter for a `trace_demo` service.
     ///
-    /// let otlp_exporter = opentelemetry_otlp::new_exporter().tonic();
-    /// let tracer = opentelemetry_otlp::new_pipeline()
-    ///     .tracing()
-    ///     .with_exporter(otlp_exporter)
-    ///     .install_simple()
-    ///     .unwrap()
+    /// let otlp_exporter = opentelemetry_otlp::SpanExporter::builder()
+    ///     .with_tonic()
+    ///     .build()
+    ///     .unwrap();
+    ///
+    /// let tracer = opentelemetry_sdk::trace::TracerProvider::builder()
+    ///     .with_simple_exporter(otlp_exporter)
+    ///     .build()
     ///     .tracer("trace_demo");
     ///
     /// // Create a layer with the configured tracer

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -6,7 +6,7 @@ use tracing_core::{Field, Interest, Metadata};
 use opentelemetry::metrics::Gauge;
 use opentelemetry::{
     metrics::{Counter, Histogram, Meter, MeterProvider, UpDownCounter},
-    KeyValue, Value,
+    InstrumentationScope, KeyValue, Value,
 };
 use tracing_subscriber::{
     filter::Filtered,
@@ -98,7 +98,7 @@ impl Instruments {
                 update_or_insert(
                     &self.u64_counter,
                     metric_name,
-                    || meter.u64_counter(metric_name).init(),
+                    || meter.u64_counter(metric_name).build(),
                     |ctr| ctr.add(value, attributes),
                 );
             }
@@ -106,7 +106,7 @@ impl Instruments {
                 update_or_insert(
                     &self.f64_counter,
                     metric_name,
-                    || meter.f64_counter(metric_name).init(),
+                    || meter.f64_counter(metric_name).build(),
                     |ctr| ctr.add(value, attributes),
                 );
             }
@@ -114,7 +114,7 @@ impl Instruments {
                 update_or_insert(
                     &self.i64_up_down_counter,
                     metric_name,
-                    || meter.i64_up_down_counter(metric_name).init(),
+                    || meter.i64_up_down_counter(metric_name).build(),
                     |ctr| ctr.add(value, attributes),
                 );
             }
@@ -122,7 +122,7 @@ impl Instruments {
                 update_or_insert(
                     &self.f64_up_down_counter,
                     metric_name,
-                    || meter.f64_up_down_counter(metric_name).init(),
+                    || meter.f64_up_down_counter(metric_name).build(),
                     |ctr| ctr.add(value, attributes),
                 );
             }
@@ -130,7 +130,7 @@ impl Instruments {
                 update_or_insert(
                     &self.u64_histogram,
                     metric_name,
-                    || meter.u64_histogram(metric_name).init(),
+                    || meter.u64_histogram(metric_name).build(),
                     |rec| rec.record(value, attributes),
                 );
             }
@@ -138,7 +138,7 @@ impl Instruments {
                 update_or_insert(
                     &self.f64_histogram,
                     metric_name,
-                    || meter.f64_histogram(metric_name).init(),
+                    || meter.f64_histogram(metric_name).build(),
                     |rec| rec.record(value, attributes),
                 );
             }
@@ -147,7 +147,7 @@ impl Instruments {
                 update_or_insert(
                     &self.u64_gauge,
                     metric_name,
-                    || meter.u64_gauge(metric_name).init(),
+                    || meter.u64_gauge(metric_name).build(),
                     |rec| rec.record(value, attributes),
                 );
             }
@@ -156,7 +156,7 @@ impl Instruments {
                 update_or_insert(
                     &self.i64_gauge,
                     metric_name,
-                    || meter.i64_gauge(metric_name).init(),
+                    || meter.i64_gauge(metric_name).build(),
                     |rec| rec.record(value, attributes),
                 );
             }
@@ -165,7 +165,7 @@ impl Instruments {
                 update_or_insert(
                     &self.f64_gauge,
                     metric_name,
-                    || meter.f64_gauge(metric_name).init(),
+                    || meter.f64_gauge(metric_name).build(),
                     |rec| rec.record(value, attributes),
                 );
             }
@@ -395,11 +395,10 @@ where
     where
         M: MeterProvider,
     {
-        let meter = meter_provider.versioned_meter(
-            INSTRUMENTATION_LIBRARY_NAME,
-            Some(CARGO_PKG_VERSION),
-            None::<&'static str>,
-            None,
+        let meter = meter_provider.meter_with_scope(
+            InstrumentationScope::builder(INSTRUMENTATION_LIBRARY_NAME)
+                .with_version(CARGO_PKG_VERSION)
+                .build(),
         );
 
         let layer = InstrumentLayer {


### PR DESCRIPTION
## Motivation

New version 0.27.0 of the opentelemetry crates was recently released.

## Solution

I've updated the dependencies and fixed any outstanding compilation issues caused by breaking changes in the upstream.

Two caveats:

* I was not able to resolve the compilation issues with https://github.com/tokio-rs/tracing-opentelemetry/blob/95f9ab97e239e5789d71b9636445d89e47612f65/benches/metrics.rs since the `NoopMeterProvider` has been hidden: https://github.com/open-telemetry/opentelemetry-rust/pull/2191
* The metric "views" are now gated behind the feature `spec_unstable_metrics_views`, and I wasn't sure whether to still include it in the example: https://github.com/MathiasPius/tracing-opentelemetry/blob/d18214596c97b1243ee955a63bed3875a4f8f5f9/examples/opentelemetry-otlp.rs#L47-L82

