### PR TITLE
Upgrade to opentelemetry v0.28.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,12 +19,10 @@ rust-version = "1.70.0"
 default = ["tracing-log", "metrics"]
 # Enables support for exporting OpenTelemetry metrics
 metrics = ["opentelemetry/metrics","opentelemetry_sdk/metrics", "smallvec"]
-# Enables experimental support for OpenTelemetry gauge metrics
-metrics_gauge_unstable = ["opentelemetry/otel_unstable"]
 
 [dependencies]
-opentelemetry = { version = "0.27.0", default-features = false, features = ["trace"] }
-opentelemetry_sdk = { version = "0.27.0", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.28.0", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.28.0", default-features = false, features = ["trace"] }
 tracing = { version = "0.1.35", default-features = false, features = ["std"] }
 tracing-core = "0.1.28"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
@@ -43,11 +41,11 @@ smallvec = { version = "1.0", optional = true }
 [dev-dependencies]
 async-trait = "0.1.56"
 criterion = { version = "0.5.1", default-features = false, features = ["html_reports"] }
-opentelemetry = { version = "0.27.0", features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.27.0", default-features = false, features = ["trace", "rt-tokio"] }
-opentelemetry-stdout = { version = "0.27.0", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.27.0", features = ["metrics"] }
-opentelemetry-semantic-conventions = { version = "0.27.0", features = ["semconv_experimental"] }
+opentelemetry = { version = "0.28.0", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.28.0", default-features = false, features = ["trace", "rt-tokio"] }
+opentelemetry-stdout = { version = "0.28.0", features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.28.0", features = ["grpc-tonic", "metrics"] }
+opentelemetry-semantic-conventions = { version = "0.28.0", features = ["semconv_experimental"] }
 futures-util = { version = "0.3.17", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/examples/basic.rs
+++ b/examples/basic.rs
@@ -1,5 +1,5 @@
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry_sdk::trace::TracerProvider;
+use opentelemetry_sdk::trace::SdkTracerProvider;
 use opentelemetry_stdout as stdout;
 use tracing::{error, span};
 use tracing_subscriber::layer::SubscriberExt;
@@ -7,7 +7,7 @@ use tracing_subscriber::Registry;
 
 fn main() {
     // Create a new OpenTelemetry trace pipeline that prints to stdout
-    let provider = TracerProvider::builder()
+    let provider = SdkTracerProvider::builder()
         .with_simple_exporter(stdout::SpanExporter::default())
         .build();
     let tracer = provider.tracer("readme_example");

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -546,7 +546,7 @@ where
     ///     .build()
     ///     .unwrap();
     ///
-    /// let tracer = opentelemetry_sdk::trace::TracerProvider::builder()
+    /// let tracer = opentelemetry_sdk::trace::SdkTracerProvider::builder()
     ///     .with_simple_exporter(otlp_exporter)
     ///     .build()
     ///     .tracer("trace_demo");
@@ -598,7 +598,7 @@ where
     ///     .build()
     ///     .unwrap();
     ///
-    /// let tracer = opentelemetry_sdk::trace::TracerProvider::builder()
+    /// let tracer = opentelemetry_sdk::trace::SdkTracerProvider::builder()
     ///     .with_simple_exporter(otlp_exporter)
     ///     .build()
     ///     .tracer("trace_demo");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -51,14 +51,14 @@
 //! ## Examples
 //!
 //! ```
-//! use opentelemetry_sdk::trace::TracerProvider;
+//! use opentelemetry_sdk::trace::SdkTracerProvider;
 //! use opentelemetry::trace::{Tracer, TracerProvider as _};
 //! use tracing::{error, span};
 //! use tracing_subscriber::layer::SubscriberExt;
 //! use tracing_subscriber::Registry;
 //!
 //! // Create a new OpenTelemetry trace pipeline that prints to stdout
-//! let provider = TracerProvider::builder()
+//! let provider = SdkTracerProvider::builder()
 //!     .with_simple_exporter(opentelemetry_stdout::SpanExporter::default())
 //!     .build();
 //! let tracer = provider.tracer("readme_example");

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2,7 +2,6 @@ use std::{collections::HashMap, fmt, sync::RwLock};
 use tracing::{field::Visit, Subscriber};
 use tracing_core::{Field, Interest, Metadata};
 
-#[cfg(feature = "metrics_gauge_unstable")]
 use opentelemetry::metrics::Gauge;
 use opentelemetry::{
     metrics::{Counter, Histogram, Meter, MeterProvider, UpDownCounter},
@@ -23,7 +22,6 @@ const INSTRUMENTATION_LIBRARY_NAME: &str = "tracing/tracing-opentelemetry";
 const METRIC_PREFIX_MONOTONIC_COUNTER: &str = "monotonic_counter.";
 const METRIC_PREFIX_COUNTER: &str = "counter.";
 const METRIC_PREFIX_HISTOGRAM: &str = "histogram.";
-#[cfg(feature = "metrics_gauge_unstable")]
 const METRIC_PREFIX_GAUGE: &str = "gauge.";
 
 const I64_MAX: u64 = i64::MAX as u64;
@@ -36,11 +34,8 @@ pub(crate) struct Instruments {
     f64_up_down_counter: MetricsMap<UpDownCounter<f64>>,
     u64_histogram: MetricsMap<Histogram<u64>>,
     f64_histogram: MetricsMap<Histogram<f64>>,
-    #[cfg(feature = "metrics_gauge_unstable")]
     u64_gauge: MetricsMap<Gauge<u64>>,
-    #[cfg(feature = "metrics_gauge_unstable")]
     i64_gauge: MetricsMap<Gauge<i64>>,
-    #[cfg(feature = "metrics_gauge_unstable")]
     f64_gauge: MetricsMap<Gauge<f64>>,
 }
 
@@ -54,11 +49,8 @@ pub(crate) enum InstrumentType {
     UpDownCounterF64(f64),
     HistogramU64(u64),
     HistogramF64(f64),
-    #[cfg(feature = "metrics_gauge_unstable")]
     GaugeU64(u64),
-    #[cfg(feature = "metrics_gauge_unstable")]
     GaugeI64(i64),
-    #[cfg(feature = "metrics_gauge_unstable")]
     GaugeF64(f64),
 }
 
@@ -142,7 +134,6 @@ impl Instruments {
                     |rec| rec.record(value, attributes),
                 );
             }
-            #[cfg(feature = "metrics_gauge_unstable")]
             InstrumentType::GaugeU64(value) => {
                 update_or_insert(
                     &self.u64_gauge,
@@ -151,7 +142,6 @@ impl Instruments {
                     |rec| rec.record(value, attributes),
                 );
             }
-            #[cfg(feature = "metrics_gauge_unstable")]
             InstrumentType::GaugeI64(value) => {
                 update_or_insert(
                     &self.i64_gauge,
@@ -160,7 +150,6 @@ impl Instruments {
                     |rec| rec.record(value, attributes),
                 );
             }
-            #[cfg(feature = "metrics_gauge_unstable")]
             InstrumentType::GaugeF64(value) => {
                 update_or_insert(
                     &self.f64_gauge,
@@ -185,7 +174,6 @@ impl Visit for MetricVisitor<'_> {
     }
 
     fn record_u64(&mut self, field: &Field, value: u64) {
-        #[cfg(feature = "metrics_gauge_unstable")]
         if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_GAUGE) {
             self.visited_metrics
                 .push((metric_name, InstrumentType::GaugeU64(value)));
@@ -216,7 +204,6 @@ impl Visit for MetricVisitor<'_> {
     }
 
     fn record_f64(&mut self, field: &Field, value: f64) {
-        #[cfg(feature = "metrics_gauge_unstable")]
         if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_GAUGE) {
             self.visited_metrics
                 .push((metric_name, InstrumentType::GaugeF64(value)));
@@ -238,7 +225,6 @@ impl Visit for MetricVisitor<'_> {
     }
 
     fn record_i64(&mut self, field: &Field, value: i64) {
-        #[cfg(feature = "metrics_gauge_unstable")]
         if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_GAUGE) {
             self.visited_metrics
                 .push((metric_name, InstrumentType::GaugeI64(value)));
@@ -427,7 +413,6 @@ impl MetricsFilter {
                     return true;
                 }
 
-                #[cfg(feature = "metrics_gauge_unstable")]
                 if name.starts_with(METRIC_PREFIX_GAUGE) {
                     return true;
                 }

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -152,11 +152,11 @@ mod tests {
     use super::*;
     use crate::OtelData;
     use opentelemetry::trace::TracerProvider as _;
-    use opentelemetry_sdk::trace::{Sampler, TracerProvider};
+    use opentelemetry_sdk::trace::{Sampler, SdkTracerProvider};
 
     #[test]
     fn assigns_default_trace_id_if_missing() {
-        let provider = TracerProvider::default();
+        let provider = SdkTracerProvider::default();
         let tracer = provider.tracer("test");
         let mut builder = SpanBuilder::from_name("empty".to_string());
         builder.span_id = Some(SpanId::from(1u64));
@@ -195,7 +195,7 @@ mod tests {
     #[test]
     fn sampled_context() {
         for (name, sampler, parent_cx, previous_sampling_result, is_sampled) in sampler_data() {
-            let provider = TracerProvider::builder().with_sampler(sampler).build();
+            let provider = SdkTracerProvider::builder().with_sampler(sampler).build();
             let tracer = provider.tracer("test");
             let mut builder = SpanBuilder::from_name("parent".to_string());
             builder.sampling_result = previous_sampling_result;

--- a/tests/filtered.rs
+++ b/tests/filtered.rs
@@ -1,8 +1,8 @@
 use futures_util::future::BoxFuture;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::{
-    export::trace::{ExportResult, SpanData, SpanExporter},
-    trace::{Tracer, TracerProvider},
+    error::OTelSdkResult,
+    trace::{SdkTracerProvider, SpanData, SpanExporter, Tracer},
 };
 use std::sync::{Arc, Mutex};
 use tracing::level_filters::LevelFilter;
@@ -14,7 +14,7 @@ use tracing_subscriber::prelude::*;
 struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
 
 impl SpanExporter for TestExporter {
-    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
         let spans = self.0.clone();
         Box::pin(async move {
             if let Ok(mut inner) = spans.lock() {
@@ -25,9 +25,9 @@ impl SpanExporter for TestExporter {
     }
 }
 
-fn test_tracer() -> (Tracer, TracerProvider, TestExporter, impl Subscriber) {
+fn test_tracer() -> (Tracer, SdkTracerProvider, TestExporter, impl Subscriber) {
     let exporter = TestExporter::default();
-    let provider = TracerProvider::builder()
+    let provider = SdkTracerProvider::builder()
         .with_simple_exporter(exporter.clone())
         .build();
     let tracer = provider.tracer("test");

--- a/tests/follows_from.rs
+++ b/tests/follows_from.rs
@@ -1,8 +1,8 @@
 use futures_util::future::BoxFuture;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::{
-    export::trace::{ExportResult, SpanData, SpanExporter},
-    trace::{Tracer, TracerProvider},
+    error::OTelSdkResult,
+    trace::{SdkTracerProvider, SpanData, SpanExporter, Tracer},
 };
 use std::sync::{Arc, Mutex};
 use tracing::Subscriber;
@@ -13,7 +13,7 @@ use tracing_subscriber::prelude::*;
 struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
 
 impl SpanExporter for TestExporter {
-    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
         let spans = self.0.clone();
         Box::pin(async move {
             if let Ok(mut inner) = spans.lock() {
@@ -24,9 +24,9 @@ impl SpanExporter for TestExporter {
     }
 }
 
-fn test_tracer() -> (Tracer, TracerProvider, TestExporter, impl Subscriber) {
+fn test_tracer() -> (Tracer, SdkTracerProvider, TestExporter, impl Subscriber) {
     let exporter = TestExporter::default();
-    let provider = TracerProvider::builder()
+    let provider = SdkTracerProvider::builder()
         .with_simple_exporter(exporter.clone())
         .build();
     let tracer = provider.tracer("test");

--- a/tests/metrics_publishing.rs
+++ b/tests/metrics_publishing.rs
@@ -1,5 +1,6 @@
 use opentelemetry::KeyValue;
 use opentelemetry_sdk::{
+    error::OTelSdkResult,
     metrics::{
         data::{self, Gauge, Histogram, Sum},
         reader::MetricReader,
@@ -112,7 +113,6 @@ async fn f64_up_down_counter_is_exported() {
     exporter.export().unwrap();
 }
 
-#[cfg(feature = "metrics_gauge_unstable")]
 #[tokio::test]
 async fn u64_gauge_is_exported() {
     let (subscriber, exporter) =
@@ -126,7 +126,6 @@ async fn u64_gauge_is_exported() {
     exporter.export().unwrap();
 }
 
-#[cfg(feature = "metrics_gauge_unstable")]
 #[tokio::test]
 async fn f64_gauge_is_exported() {
     let (subscriber, exporter) =
@@ -140,7 +139,6 @@ async fn f64_gauge_is_exported() {
     exporter.export().unwrap();
 }
 
-#[cfg(feature = "metrics_gauge_unstable")]
 #[tokio::test]
 async fn i64_gauge_is_exported() {
     let (subscriber, exporter) =
@@ -302,7 +300,6 @@ async fn f64_up_down_counter_with_attributes_is_exported() {
     exporter.export().unwrap();
 }
 
-#[cfg(feature = "metrics_gauge_unstable")]
 #[tokio::test]
 async fn f64_gauge_with_attributes_is_exported() {
     let (subscriber, exporter) = init_subscriber(
@@ -332,7 +329,6 @@ async fn f64_gauge_with_attributes_is_exported() {
     exporter.export().unwrap();
 }
 
-#[cfg(feature = "metrics_gauge_unstable")]
 #[tokio::test]
 async fn u64_gauge_with_attributes_is_exported() {
     let (subscriber, exporter) = init_subscriber(
@@ -362,7 +358,6 @@ async fn u64_gauge_with_attributes_is_exported() {
     exporter.export().unwrap();
 }
 
-#[cfg(feature = "metrics_gauge_unstable")]
 #[tokio::test]
 async fn i64_gauge_with_attributes_is_exported() {
     let (subscriber, exporter) = init_subscriber(
@@ -554,11 +549,12 @@ impl MetricReader for TestReader {
         self.inner.collect(rm)
     }
 
-    fn force_flush(&self) -> opentelemetry_sdk::metrics::MetricResult<()> {
+    fn force_flush(&self) -> OTelSdkResult {
         self.inner.force_flush()
     }
 
-    fn shutdown(&self) -> opentelemetry_sdk::metrics::MetricResult<()> {
+    fn shutdown(&self) -> OTelSdkResult {
+        eprintln!("OUTER shutdown??!!!");
         self.inner.shutdown()
     }
 
@@ -582,7 +578,7 @@ where
 {
     fn export(&self) -> Result<(), MetricError> {
         let mut rm = data::ResourceMetrics {
-            resource: Resource::default(),
+            resource: Resource::builder().build(),
             scope_metrics: Vec::new(),
         };
         self.reader.collect(&mut rm)?;

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -1,9 +1,7 @@
 use futures_util::future::BoxFuture;
 use opentelemetry::trace::TracerProvider as _;
-use opentelemetry_sdk::{
-    export::trace::{ExportResult, SpanData, SpanExporter},
-    trace::{SpanLimits, Tracer, TracerProvider},
-};
+use opentelemetry_sdk::error::OTelSdkResult;
+use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter, SpanLimits, Tracer};
 use std::sync::{Arc, Mutex};
 use tracing::level_filters::LevelFilter;
 use tracing::Subscriber;
@@ -14,7 +12,7 @@ use tracing_subscriber::prelude::*;
 struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
 
 impl SpanExporter for TestExporter {
-    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
         let spans = self.0.clone();
         Box::pin(async move {
             if let Ok(mut inner) = spans.lock() {
@@ -27,12 +25,12 @@ impl SpanExporter for TestExporter {
 
 fn test_tracer() -> (
     Tracer,
-    TracerProvider,
+    SdkTracerProvider,
     TestExporter,
     impl Subscriber + Clone,
 ) {
     let exporter = TestExporter::default();
-    let provider = TracerProvider::builder()
+    let provider = SdkTracerProvider::builder()
         .with_simple_exporter(exporter.clone())
         // `with_max_events_per_span()` is buggy https://github.com/open-telemetry/opentelemetry-rust/pull/2405
         .with_span_limits(SpanLimits {

--- a/tests/parents.rs
+++ b/tests/parents.rs
@@ -1,8 +1,8 @@
 use futures_util::future::BoxFuture;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::{
-    export::trace::{ExportResult, SpanData, SpanExporter},
-    trace::{Tracer, TracerProvider},
+    error::OTelSdkResult,
+    trace::{SdkTracerProvider, SpanData, SpanExporter, Tracer},
 };
 use std::sync::{Arc, Mutex};
 use tracing::level_filters::LevelFilter;
@@ -14,7 +14,7 @@ use tracing_subscriber::prelude::*;
 struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
 
 impl SpanExporter for TestExporter {
-    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
         let spans = self.0.clone();
         Box::pin(async move {
             if let Ok(mut inner) = spans.lock() {
@@ -25,9 +25,9 @@ impl SpanExporter for TestExporter {
     }
 }
 
-fn test_tracer() -> (Tracer, TracerProvider, TestExporter, impl Subscriber) {
+fn test_tracer() -> (Tracer, SdkTracerProvider, TestExporter, impl Subscriber) {
     let exporter = TestExporter::default();
-    let provider = TracerProvider::builder()
+    let provider = SdkTracerProvider::builder()
         .with_simple_exporter(exporter.clone())
         .build();
     let tracer = provider.tracer("test");

--- a/tests/span_ext.rs
+++ b/tests/span_ext.rs
@@ -1,8 +1,8 @@
 use futures_util::future::BoxFuture;
 use opentelemetry::trace::{Status, TracerProvider as _};
 use opentelemetry_sdk::{
-    export::trace::{ExportResult, SpanData, SpanExporter},
-    trace::{Tracer, TracerProvider},
+    error::OTelSdkResult,
+    trace::{SdkTracerProvider, SpanData, SpanExporter, Tracer},
 };
 use std::sync::{Arc, Mutex};
 use tracing::level_filters::LevelFilter;
@@ -14,7 +14,7 @@ use tracing_subscriber::prelude::*;
 struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
 
 impl SpanExporter for TestExporter {
-    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, ExportResult> {
+    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
         let spans = self.0.clone();
         Box::pin(async move {
             if let Ok(mut inner) = spans.lock() {
@@ -25,9 +25,9 @@ impl SpanExporter for TestExporter {
     }
 }
 
-fn test_tracer() -> (Tracer, TracerProvider, TestExporter, impl Subscriber) {
+fn test_tracer() -> (Tracer, SdkTracerProvider, TestExporter, impl Subscriber) {
     let exporter = TestExporter::default();
-    let provider = TracerProvider::builder()
+    let provider = SdkTracerProvider::builder()
         .with_simple_exporter(exporter.clone())
         .build();
     let tracer = provider.tracer("test");


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing-opentelemetry/blob/master/CONTRIBUTING.md
-->

## Motivation

opentelemetry-rust upgraded their crates to 0.28

I've been working through the migration guide here: https://github.com/open-telemetry/opentelemetry-rust/blob/main/docs/migration_0.28.md

This package was one of the dependencies that I am using that hasn't upgraded to handle the breaking changes. This is my attempt to fix them. All the tests seem to pass for me locally.

There is an issue with the SdkMeterProvider not properly shutting down. The root of the error I was able to see said this: `Status { code: Unimplemented, message: "unknown service opentelemetry.proto.collector.metrics.v1.MetricsService", metadata: MetadataMap { headers: {"content-type": "application/grpc"} }, source: None }`. I am not super knowledgeable around this area, so I'm not sure what exactly needs to be fixed here, BUT, it seems to also happen with the [basic-oltp](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-otlp/examples/basic-otlp/src/main.rs) example itself, so it seems like the error is likely out of scope of this repo. I'm going to open an issue there for that error and maybe we can get that figured out too.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Update the versions to 0.28 and fix the breaking changes.
