### PR TITLE
doc: tracked inactivity default

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -729,6 +729,8 @@ where
     /// Sets whether or not spans metadata should include the _busy time_
     /// (total time for which it was entered), and _idle time_ (total time
     /// the span existed but was not entered).
+    ///
+    /// By default, inactivity tracking is enabled.
     pub fn with_tracked_inactivity(self, tracked_inactivity: bool) -> Self {
         Self {
             tracked_inactivity,


### PR DESCRIPTION
## Motivation

The documentation doesn't provide the default value of tracked_inactivity for `OpenTelemetryLayer` .

## Solution

Specify that, by default, inactivity tracking is enabled.
