### PR TITLE
chore: update from opentelemetry-sdk 0.28.0 to 0.29.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+# Unreleased
+
+### Breaking Changes
+
+- Upgrade from opentelemetry 0.28.0 to 0.29.0. Refer to the upstream
+  [changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-sdk/CHANGELOG.md#0290)
+  for more information.
+
 # 0.27.0 (October 9, 2024)
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ metrics = ["opentelemetry/metrics","opentelemetry_sdk/metrics", "smallvec"]
 metrics_gauge_unstable = []
 
 [dependencies]
-opentelemetry = { version = "0.28.0", default-features = false, features = ["trace"] }
-opentelemetry_sdk = { version = "0.28.0", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.29.0", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.29.0", default-features = false, features = ["trace"] }
 tracing = { version = "0.1.35", default-features = false, features = ["std"] }
 tracing-core = "0.1.28"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
@@ -43,11 +43,11 @@ smallvec = { version = "1.0", optional = true }
 [dev-dependencies]
 async-trait = "0.1.56"
 criterion = { version = "0.5.1", default-features = false, features = ["html_reports"] }
-opentelemetry = { version = "0.28.0", features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.28.0", default-features = false, features = ["trace", "rt-tokio"] }
-opentelemetry-stdout = { version = "0.28.0", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.28.0", features = ["metrics", "grpc-tonic"] }
-opentelemetry-semantic-conventions = { version = "0.28.0", features = ["semconv_experimental"] }
+opentelemetry = { version = "0.29.0", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.29.0", default-features = false, features = ["trace", "rt-tokio"] }
+opentelemetry-stdout = { version = "0.29.0", features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.29.0", features = ["metrics", "grpc-tonic"] }
+opentelemetry-semantic-conventions = { version = "0.29.0", features = ["semconv_experimental"] }
 futures-util = { version = "0.3.17", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"

--- a/examples/opentelemetry-error.rs
+++ b/examples/opentelemetry-error.rs
@@ -92,17 +92,17 @@ fn main() -> Result<(), Box<dyn StdError + Send + Sync + 'static>> {
 struct WriterExporter;
 
 impl SpanExporter for WriterExporter {
-    fn export(
-        &mut self,
+    async fn export(
+        &self,
         batch: Vec<sdk::trace::SpanData>,
-    ) -> futures_util::future::BoxFuture<'static, OTelSdkResult> {
+    ) -> OTelSdkResult {
         let mut writer = std::io::stdout();
         for span in batch {
             writeln!(writer, "{}", SpanData(span)).unwrap();
         }
         writeln!(writer).unwrap();
 
-        Box::pin(async move { OTelSdkResult::Ok(()) })
+        OTelSdkResult::Ok(())
     }
 }
 

--- a/examples/opentelemetry-error.rs
+++ b/examples/opentelemetry-error.rs
@@ -92,10 +92,7 @@ fn main() -> Result<(), Box<dyn StdError + Send + Sync + 'static>> {
 struct WriterExporter;
 
 impl SpanExporter for WriterExporter {
-    async fn export(
-        &self,
-        batch: Vec<sdk::trace::SpanData>,
-    ) -> OTelSdkResult {
+    async fn export(&self, batch: Vec<sdk::trace::SpanData>) -> OTelSdkResult {
         let mut writer = std::io::stdout();
         for span in batch {
             writeln!(writer, "{}", SpanData(span)).unwrap();

--- a/tests/batch_global_subscriber.rs
+++ b/tests/batch_global_subscriber.rs
@@ -1,4 +1,3 @@
-use futures_util::future::BoxFuture;
 use opentelemetry::{global as otel_global, trace::TracerProvider as _};
 use opentelemetry_sdk::{
     error::OTelSdkResult,
@@ -16,14 +15,12 @@ use std::sync::{Arc, Mutex};
 struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
 
 impl SpanExporter for TestExporter {
-    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
+    async fn export(&self, mut batch: Vec<SpanData>) -> OTelSdkResult {
         let spans = self.0.clone();
-        Box::pin(async move {
-            if let Ok(mut inner) = spans.lock() {
-                inner.append(&mut batch);
-            }
-            Ok(())
-        })
+        if let Ok(mut inner) = spans.lock() {
+            inner.append(&mut batch);
+        }
+        Ok(())
     }
 }
 

--- a/tests/errors.rs
+++ b/tests/errors.rs
@@ -1,4 +1,3 @@
-use futures_util::future::BoxFuture;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter, Tracer};
@@ -106,13 +105,11 @@ fn test_tracer(
 struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
 
 impl SpanExporter for TestExporter {
-    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
+    async fn export(&self, mut batch: Vec<SpanData>) -> OTelSdkResult {
         let spans = self.0.clone();
-        Box::pin(async move {
-            if let Ok(mut inner) = spans.lock() {
-                inner.append(&mut batch);
-            }
-            Ok(())
-        })
+        if let Ok(mut inner) = spans.lock() {
+            inner.append(&mut batch);
+        }
+        Ok(())
     }
 }

--- a/tests/filtered.rs
+++ b/tests/filtered.rs
@@ -1,4 +1,3 @@
-use futures_util::future::BoxFuture;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter, Tracer};
@@ -12,14 +11,12 @@ use tracing_subscriber::prelude::*;
 struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
 
 impl SpanExporter for TestExporter {
-    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
+    async fn export(&self, mut batch: Vec<SpanData>) -> OTelSdkResult {
         let spans = self.0.clone();
-        Box::pin(async move {
-            if let Ok(mut inner) = spans.lock() {
-                inner.append(&mut batch);
-            }
-            Ok(())
-        })
+        if let Ok(mut inner) = spans.lock() {
+            inner.append(&mut batch);
+        }
+        Ok(())
     }
 }
 

--- a/tests/follows_from.rs
+++ b/tests/follows_from.rs
@@ -1,4 +1,3 @@
-use futures_util::future::BoxFuture;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::{
     error::OTelSdkResult,
@@ -13,14 +12,12 @@ use tracing_subscriber::prelude::*;
 struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
 
 impl SpanExporter for TestExporter {
-    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
+    async fn export(&self, mut batch: Vec<SpanData>) -> OTelSdkResult {
         let spans = self.0.clone();
-        Box::pin(async move {
-            if let Ok(mut inner) = spans.lock() {
-                inner.append(&mut batch);
-            }
-            Ok(())
-        })
+        if let Ok(mut inner) = spans.lock() {
+            inner.append(&mut batch);
+        }
+        Ok(())
     }
 }
 

--- a/tests/parallel.rs
+++ b/tests/parallel.rs
@@ -1,4 +1,3 @@
-use futures_util::future::BoxFuture;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter, SpanLimits, Tracer};
@@ -12,14 +11,12 @@ use tracing_subscriber::prelude::*;
 struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
 
 impl SpanExporter for TestExporter {
-    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
+    async fn export(&self, mut batch: Vec<SpanData>) -> OTelSdkResult {
         let spans = self.0.clone();
-        Box::pin(async move {
-            if let Ok(mut inner) = spans.lock() {
-                inner.append(&mut batch);
-            }
-            Ok(())
-        })
+        if let Ok(mut inner) = spans.lock() {
+            inner.append(&mut batch);
+        }
+        Ok(())
     }
 }
 

--- a/tests/parents.rs
+++ b/tests/parents.rs
@@ -1,4 +1,3 @@
-use futures_util::future::BoxFuture;
 use opentelemetry::trace::TracerProvider as _;
 use opentelemetry_sdk::error::OTelSdkResult;
 use opentelemetry_sdk::trace::{SdkTracerProvider, SpanData, SpanExporter, Tracer};
@@ -12,14 +11,12 @@ use tracing_subscriber::prelude::*;
 struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
 
 impl SpanExporter for TestExporter {
-    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
+    async fn export(&self, mut batch: Vec<SpanData>) -> OTelSdkResult {
         let spans = self.0.clone();
-        Box::pin(async move {
-            if let Ok(mut inner) = spans.lock() {
-                inner.append(&mut batch);
-            }
-            Ok(())
-        })
+        if let Ok(mut inner) = spans.lock() {
+            inner.append(&mut batch);
+        }
+        Ok(())
     }
 }
 

--- a/tests/span_ext.rs
+++ b/tests/span_ext.rs
@@ -1,4 +1,3 @@
-use futures_util::future::BoxFuture;
 use opentelemetry::trace::{Status, TracerProvider as _};
 use opentelemetry_sdk::{
     error::OTelSdkResult,
@@ -14,14 +13,12 @@ use tracing_subscriber::prelude::*;
 struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
 
 impl SpanExporter for TestExporter {
-    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
+    async fn export(&self, mut batch: Vec<SpanData>) -> OTelSdkResult {
         let spans = self.0.clone();
-        Box::pin(async move {
-            if let Ok(mut inner) = spans.lock() {
-                inner.append(&mut batch);
-            }
-            Ok(())
-        })
+        if let Ok(mut inner) = spans.lock() {
+            inner.append(&mut batch);
+        }
+        Ok(())
     }
 }
 

--- a/tests/trace_state_propagation.rs
+++ b/tests/trace_state_propagation.rs
@@ -1,4 +1,3 @@
-use futures_util::future::BoxFuture;
 use opentelemetry::{
     propagation::{TextMapCompositePropagator, TextMapPropagator},
     trace::{SpanContext, TraceContextExt, Tracer as _, TracerProvider as _},
@@ -218,13 +217,11 @@ fn build_sampled_context() -> (Context, impl Subscriber, TestExporter, SdkTracer
 struct TestExporter(Arc<Mutex<Vec<SpanData>>>);
 
 impl SpanExporter for TestExporter {
-    fn export(&mut self, mut batch: Vec<SpanData>) -> BoxFuture<'static, OTelSdkResult> {
+    async fn export(&self, mut batch: Vec<SpanData>) -> OTelSdkResult {
         let spans = self.0.clone();
-        Box::pin(async move {
-            if let Ok(mut inner) = spans.lock() {
-                inner.append(&mut batch);
-            }
-            Ok(())
-        })
+        if let Ok(mut inner) = spans.lock() {
+            inner.append(&mut batch);
+        }
+        Ok(())
     }
 }


### PR DESCRIPTION
## Motivation

This PR updates the dependencies from opentelemetry 0.28.0 to 0.29.0. The update requires adapting to breaking changes in the `SpanExporter` trait interface, which now requires immutable references (`&self` instead of `&mut self`) and uses `async fn` syntax rather than returning `BoxFuture`.

## Solution

- Updated opentelemetry dependencies from 0.28.0 to 0.29.0 in Cargo.toml
- Updated all `SpanExporter` trait implementations in test files and examples to match the breaking changes in the 0.29.0 release:
  - Changed `&mut self` to `&self` in method signatures
  - Changed return type from `BoxFuture<'static, OTelSdkResult>` to using `async fn` that returns `OTelSdkResult` directly
  - Removed unnecessary `BoxFuture` imports
- Updated CHANGELOG.md with the breaking change

The specific breaking changes in opentelemetry-sdk 0.29.0 that affected this crate are documented in the [upstream changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-sdk/CHANGELOG.md#0290):

> **Breaking** The SpanExporter::export() method no longer requires a mutable reference to self. Before:  
> `async fn export(&mut self, batch: Vec<SpanData>) -> OTelSdkResult`  
> After:  
> `async fn export(&self, batch: Vec<SpanData>) -> OTelSdkResult`

All tests and examples have been verified to build and run correctly with these changes.