### PR TITLE
feat: Add OpenTelemetrySpanExt methods for direct span event creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+### Added
+
+- Add `OpenTelemetrySpanExt::add_event` and `OpenTelemetrySpanExt::add_event_with_timestamp` 
+  functions to allow adding OpenTelemetry events directly to a `tracing::Span`, enabling the use of dynamic attribute keys 
+  and custom event timestamps.
+
 # 0.30.0 (March 23, 2025)
 
 ### Breaking Changes

--- a/README.md
+++ b/README.md
@@ -42,7 +42,10 @@ The crate provides the following types:
 
 * [`OpenTelemetryLayer`] adds OpenTelemetry context to all `tracing` [span]s.
 * [`OpenTelemetrySpanExt`] allows OpenTelemetry parent trace information to be
-  injected and extracted from a `tracing` [span].
+  injected and extracted from a `tracing` [span]. It also provides methods
+  to directly set span attributes (`set_attribute`), span status (`set_status`),
+  and add OpenTelemetry events with dynamic attributes using the current time
+  (`add_event`) or a specific timestamp (`add_event_with_timestamp`).
 
 [`OpenTelemetryLayer`]: https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/struct.OpenTelemetryLayer.html
 [`OpenTelemetrySpanExt`]: https://docs.rs/tracing-opentelemetry/latest/tracing_opentelemetry/trait.OpenTelemetrySpanExt.html

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,8 +20,8 @@
 //! special fields are:
 //!
 //! * `otel.name`: Override the span name sent to OpenTelemetry exporters.
-//!    Setting this field is useful if you want to display non-static information
-//!    in your span name.
+//!   Setting this field is useful if you want to display non-static information
+//!   in your span name.
 //! * `otel.kind`: Set the span kind to one of the supported OpenTelemetry [span kinds].
 //! * `otel.status_code`: Set the span status code to one of the supported OpenTelemetry [span status codes].
 //! * `otel.status_message`: Set the span status message.

--- a/tests/metrics_publishing.rs
+++ b/tests/metrics_publishing.rs
@@ -625,7 +625,7 @@ where
                                 .data_points
                                 .iter()
                                 .map(|data_point| data_point.value)
-                                .last()
+                                .next_back()
                                 .unwrap()
                         );
 

--- a/tests/span_ext.rs
+++ b/tests/span_ext.rs
@@ -71,3 +71,97 @@ fn set_status_helper(status: Status) -> SpanData {
 
     spans.iter().find(|s| s.name == "root").unwrap().clone()
 }
+
+#[test]
+fn test_add_event() {
+    let (_tracer, provider, exporter, subscriber) = test_tracer();
+
+    let event_name = "my_event";
+    let event_attrs = vec![
+        opentelemetry::KeyValue::new("event_key_1", "event_value_1"),
+        opentelemetry::KeyValue::new("event_key_2", 123),
+    ];
+
+    tracing::subscriber::with_default(subscriber, || {
+        let root = tracing::debug_span!("root");
+        let _enter = root.enter(); // Enter span to make it current for the event addition
+
+        // Add the event using the new extension method
+        root.add_event(event_name, event_attrs.clone());
+    });
+
+    drop(provider); // flush all spans
+    let spans = exporter.0.lock().unwrap();
+
+    assert_eq!(spans.len(), 1, "Should have exported exactly one span.");
+    let root_span_data = spans.first().unwrap();
+
+    assert_eq!(
+        root_span_data.events.len(),
+        1,
+        "Span should have one event."
+    );
+    let event_data = root_span_data.events.first().unwrap();
+
+    assert_eq!(event_data.name, event_name, "Event name mismatch.");
+    assert_eq!(
+        event_data.attributes, event_attrs,
+        "Event attributes mismatch."
+    );
+}
+
+#[test]
+fn test_add_event_with_timestamp() {
+    use std::time::{Duration, SystemTime};
+
+    let (_tracer, provider, exporter, subscriber) = test_tracer();
+
+    let event_name = "my_specific_time_event";
+    let event_attrs = vec![opentelemetry::KeyValue::new("event_key_a", "value_a")];
+    // Define a specific timestamp (e.g., 10 seconds ago)
+    let specific_timestamp = SystemTime::now() - Duration::from_secs(10);
+
+    tracing::subscriber::with_default(subscriber, || {
+        let root = tracing::debug_span!("root_with_timestamped_event");
+        let _enter = root.enter();
+
+        // Add the event using the new extension method with the specific timestamp
+        root.add_event_with_timestamp(event_name, specific_timestamp, event_attrs.clone());
+    });
+
+    drop(provider); // flush all spans
+    let spans = exporter.0.lock().unwrap();
+
+    assert_eq!(spans.len(), 1, "Should have exported exactly one span.");
+    let root_span_data = spans.first().unwrap();
+
+    assert_eq!(
+        root_span_data.events.len(),
+        1,
+        "Span should have one event."
+    );
+    let event_data = root_span_data.events.first().unwrap();
+
+    assert_eq!(event_data.name, event_name, "Event name mismatch.");
+    assert_eq!(
+        event_data.attributes, event_attrs,
+        "Event attributes mismatch."
+    );
+
+    // Assert the timestamp matches the one we provided
+    // Allow for a small tolerance due to potential precision differences during conversion
+    let timestamp_diff = event_data
+        .timestamp
+        .duration_since(specific_timestamp)
+        .unwrap_or_else(|_| {
+            specific_timestamp
+                .duration_since(event_data.timestamp)
+                .unwrap_or_default()
+        });
+    assert!(
+        timestamp_diff < Duration::from_millis(1),
+        "Timestamp mismatch. Expected: {:?}, Got: {:?}",
+        specific_timestamp,
+        event_data.timestamp
+    );
+}


### PR DESCRIPTION
This PR adds methods to `OpenTelemetrySpanExt` for directly adding OpenTelemetry span events, addressing the limitations of using `tracing::event!` for events with dynamic attributes.

Fixes #200

## Motivation
As discussed in issue #200, the current `tracing::event!` macro requires attribute keys to be known at compile time. This makes it difficult or impossible to record OpenTelemetry span events with dynamic attributes (e.g., from processing arbitrary JSON payloads) without resorting to lossy serialization, which hinders observability.

This change provides a way to directly add `opentelemetry::trace::Event` objects with dynamic `Vec<KeyValue>` attributes, similar to how `set_attribute` allows setting dynamic span attributes. This improves flexibility, makes porting code easier, and aligns better with the capabilities of the OpenTelemetry Span API.

## Solution
This PR extends the `OpenTelemetrySpanExt` trait with two new methods:

1.  `add_otel_span_event<T>(&self, name: T, attributes: Vec<KeyValue>) where T: Into<Cow<'static, str>>`: Adds an OpenTelemetry span event with the current timestamp.
2.  `add_otel_span_event_with_timestamp<T>(&self, name: T, timestamp: SystemTime, attributes: Vec<KeyValue>) where T: Into<Cow<'static, str>>`: Adds an OpenTelemetry span event with a specified timestamp.

The implementation uses the existing `with_subscriber` -> `downcast_ref::<WithContext>` -> `with_context` pattern found in other `OpenTelemetrySpanExt` methods (`set_attribute`, `set_status`) to access the internal `OtelData` builder and push the event.

The name `add_otel_span_event` was chosen over `add_event` to avoid potential confusion with the `tracing::event!` macro within the context of this crate.

This PR includes:
- The trait method definitions and implementations in `src/span_ext.rs`.
- Corresponding test cases in `tests/span_ext.rs`.
- Updates to `README.md` documentation.
- A new example file `examples/opentelemetry-span-event.rs`.
- Updated `CHANGELOG.md`.