### PR TITLE
OTLP Example logging with incorrect ‘service.name’

### DIFF
--- a/examples/opentelemetry-otlp.rs
+++ b/examples/opentelemetry-otlp.rs
@@ -5,7 +5,7 @@ use opentelemetry_sdk::{
     Resource,
 };
 use opentelemetry_semantic_conventions::{
-    attribute::{DEPLOYMENT_ENVIRONMENT_NAME, SERVICE_NAME, SERVICE_VERSION},
+    attribute::{DEPLOYMENT_ENVIRONMENT_NAME, SERVICE_VERSION},
     SCHEMA_URL,
 };
 use tracing_core::Level;
@@ -15,9 +15,9 @@ use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 // Create a Resource that captures information about the entity for which telemetry is recorded.
 fn resource() -> Resource {
     Resource::builder()
+        .with_service_name(env!("CARGO_PKG_NAME"))
         .with_schema_url(
             [
-                KeyValue::new(SERVICE_NAME, env!("CARGO_PKG_NAME")),
                 KeyValue::new(SERVICE_VERSION, env!("CARGO_PKG_VERSION")),
                 KeyValue::new(DEPLOYMENT_ENVIRONMENT_NAME, "develop"),
             ],


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing-opentelemetry/blob/master/CONTRIBUTING.md
-->

## Motivation

Logs to Jaeger will use the service name "unknown_service" instead of the crate name as intended.

See #199 for details.

## Solution

Using `with_service_name` instead of declaring it in the Registry.
<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->
