### PR TITLE
Upgrade to otel 0.30

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Unreleased
 
+### Breaking Changes
+
+- Upgrade from opentelemetry 0.29.0 to 0.30.0. Refer to the upstream
+  [changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-sdk/CHANGELOG.md#0300)
+  for more information.
+
 ### Added
 
 - Add `OpenTelemetrySpanExt::add_event` and `OpenTelemetrySpanExt::add_event_with_timestamp` 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,8 +23,8 @@ metrics = ["opentelemetry/metrics","opentelemetry_sdk/metrics", "smallvec"]
 metrics_gauge_unstable = []
 
 [dependencies]
-opentelemetry = { version = "0.29.0", default-features = false, features = ["trace"] }
-opentelemetry_sdk = { version = "0.29.0", default-features = false, features = ["trace"] }
+opentelemetry = { version = "0.30.0", default-features = false, features = ["trace"] }
+opentelemetry_sdk = { version = "0.30.0", default-features = false, features = ["trace"] }
 tracing = { version = "0.1.35", default-features = false, features = ["std"] }
 tracing-core = "0.1.28"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
@@ -43,11 +43,11 @@ smallvec = { version = "1.0", optional = true }
 [dev-dependencies]
 async-trait = "0.1.56"
 criterion = { version = "0.5.1", default-features = false, features = ["html_reports"] }
-opentelemetry = { version = "0.29.0", features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.29.0", default-features = false, features = ["trace", "rt-tokio"] }
-opentelemetry-stdout = { version = "0.29.0", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.29.0", features = ["metrics", "grpc-tonic"] }
-opentelemetry-semantic-conventions = { version = "0.29.0", features = ["semconv_experimental"] }
+opentelemetry = { version = "0.30.0", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.30.0", default-features = false, features = ["trace", "rt-tokio", "experimental_metrics_custom_reader"] }
+opentelemetry-stdout = { version = "0.30.0", features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.30.0", features = ["metrics", "grpc-tonic"] }
+opentelemetry-semantic-conventions = { version = "0.30.0", features = ["semconv_experimental"] }
 futures-util = { version = "0.3.17", default-features = false }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing-opentelemetry/blob/master/CONTRIBUTING.md
-->

Hi, I upgraded to the newest opentelemetry 0.30 and it broke compatibility with this crate. This should hopefully fix those incompatibility issues.

## Motivation

There were some breaking changes with the upgrade to otel 0.30: https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-sdk/CHANGELOG.md#0300

I was able to fix upgrade them without much of an issue. The only compilation issues were in the metrics_publishing test. A few of the types used in that test now require the `experimental_metrics_custom_reader` feature to be enabled in the opentelemetry-sdk package.

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

## Solution

Bump the versions & fix the one test file that had compilation errors.

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Please let me know if I'm missing anything. Thanks!
