### PR TITLE
chore(deps): upgrade pprof and remove obsolete forced minimum versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,15 +30,10 @@ tracing-core = "0.1.28"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
 tracing-log = { version = "0.2.0", default-features = false, optional = true }
 once_cell = "1.13.0"
+smallvec = { version = "1.0", optional = true }
 
 # Fix minimal-versions
-async-trait = { version = "0.1.56", optional = true }
-futures-util = { version = "0.3.17", optional = true }
 lazy_static = { version = "1.0.2", optional = true }
-# Work around incorrect minimal version in opentelemetry, https://github.com/open-telemetry/opentelemetry-rust/pull/2406
-thiserror-1 = { package = "thiserror", version = "1.0.31", optional = true }
-thiserror = { version = "2", optional = true }
-smallvec = { version = "1.0", optional = true }
 
 [dev-dependencies]
 async-trait = "0.1.56"
@@ -56,7 +51,7 @@ tracing-error = "0.2.0"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std", "fmt"] }
 
 [target.'cfg(not(target_os = "windows"))'.dev-dependencies]
-pprof = { version = "0.14.0", features = ["flamegraph", "criterion"] }
+pprof = { version = "0.15.0", features = ["flamegraph", "criterion"] }
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
 js-sys = "0.3.64"


### PR DESCRIPTION
## Motivation

Clean up our dependencies.

## Solution

`pprof` was the only thing that pulled `thiserror@1` so let's get rid of it. It's just a dev dependency.

The forced versions seem to have been fixed by upgrading `opentelemetry` and its transitive dependencies.
