### PR TITLE
chore: slightly improve error message on version mismatch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -30,6 +30,7 @@ tracing-core = "0.1.28"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
 tracing-log = { version = "0.2.0", default-features = false, optional = true }
 once_cell = "1.13.0"
+rustversion = "1.0.9"
 smallvec = { version = "1.0", optional = true }
 
 # Fix minimal-versions

--- a/src/tracer.rs
+++ b/src/tracer.rs
@@ -34,6 +34,14 @@ use opentelemetry_sdk::trace::{IdGenerator, Tracer as SdkTracer};
 /// [`OpenTelemetrySpanExt::set_parent`]: crate::OpenTelemetrySpanExt::set_parent
 /// [`OpenTelemetrySpanExt::context`]: crate::OpenTelemetrySpanExt::context
 /// [`Context`]: opentelemetry::Context
+#[rustversion::attr(
+    since(1.78),
+    diagnostic::on_unimplemented(
+        note = "Make sure you're using correct `opentelemetry` versions compatible with this \
+            `tracing-opentelemetry`. The `opentelemetry` versions are usually one version lower \
+            than `tracing-opentelemetry`."
+    )
+)]
 pub trait PreSampledTracer {
     /// Produce an otel context containing an active and pre-sampled span for
     /// the given span builder data.


### PR DESCRIPTION
## Motivation

Users keep sending issues about unimplemented traits when they have wrong versions, usually after `opentelemetry` is released and before `tracing-opentelemetry` is.

## Solution

Reorder our bounds so that errors we control are shown first and add `on_unimplemented` message and note.

The errors are still very long, but now the first one should be ours (not just "type does not implement `opentelemetry::Tracer`") and we can provide more information there. It's somewhat probable some people will see the long errors and not read it at all, but this has the potential to help at least some users.

<details><summary>Example error</summary>
<p>

```
error[E0277]: the trait bound `SdkTracer: PreSampledTracer` is not satisfied. 
              This usually happens when wrong version of `opentelemetry` is used.
   --> examples/basic.rs:16:64
    |
16  |     let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
    |                                                    ----------- ^^^^^^ the trait bound `SdkTracer: PreSampledTracer` is not satisfied. This usually happens when wrong version of `opentelemetry` is used.
    |                                                    |
    |                                                    required by a bound introduced by this call
    |
    = help: the trait `PreSampledTracer` is not implemented for `SdkTracer`
    = note: Make sure you're using correct `opentelemetry` and `opentelemetry_sdk` versions compatible with this `tracing-opentelemetry`. The `opentelemetry` versions are usually one version lower than `tracing-opentelemetry`.
    = help: the following other types implement trait `PreSampledTracer`:
              opentelemetry::trace::noop::NoopTracer
              opentelemetry_sdk::trace::tracer::SdkTracer
note: required by a bound in `OpenTelemetryLayer::<S, T>::with_tracer`
   --> /home/mladedav/Personal/tracing-opentelemetry/src/layer.rs:616:17
    |
614 |     pub fn with_tracer<Tracer>(self, tracer: Tracer) -> OpenTelemetryLayer<S, Tracer>
    |            ----------- required by a bound in this associated function
615 |     where
616 |         Tracer: PreSampledTracer + otel::Tracer + 'static,
    |                 ^^^^^^^^^^^^^^^^ required by this bound in `OpenTelemetryLayer::<S, T>::with_tracer`

error[E0277]: the trait bound `SdkTracer: opentelemetry::trace::tracer::Tracer` is not satisfied
   --> examples/basic.rs:16:64
    |
16  |     let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
    |                                                    ----------- ^^^^^^ the trait `opentelemetry::trace::tracer::Tracer` is not implemented for `SdkTracer`
    |                                                    |
    |                                                    required by a bound introduced by this call
    |
note: there are multiple different versions of crate `opentelemetry` in the dependency graph
   --> /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry-0.30.0/src/trace/tracer.rs:121:1
    |
121 | pub trait Tracer {
    | ^^^^^^^^^^^^^^^^ this is the required trait
    |
   ::: examples/basic.rs:1:5
    |
1   | use opentelemetry_29::trace::TracerProvider as _;
    |     ---------------- one version of crate `opentelemetry` used here, as a direct dependency of the current crate
...
16  |     let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
    |                     --------------------- one version of crate `opentelemetry` used here, as a dependency of crate `tracing_opentelemetry`
    |
   ::: /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry_sdk-0.29.0/src/trace/tracer.rs:23:1
    |
23  | pub struct SdkTracer {
    | -------------------- this type doesn't implement the required trait
    |
   ::: /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry_sdk-0.30.0/src/trace/tracer.rs:23:1
    |
23  | pub struct SdkTracer {
    | -------------------- this type implements the required trait
    |
   ::: /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry-0.29.1/src/global/trace.rs:12:1
    |
12  | pub trait ObjectSafeSpan {
    | ------------------------ this is the found trait
    = note: two types coming from two different versions of the same crate are different types even if they look the same
    = help: you can use `cargo tree` to explore your dependency tree
note: required by a bound in `OpenTelemetryLayer::<S, T>::with_tracer`
   --> /home/mladedav/Personal/tracing-opentelemetry/src/layer.rs:616:36
    |
614 |     pub fn with_tracer<Tracer>(self, tracer: Tracer) -> OpenTelemetryLayer<S, Tracer>
    |            ----------- required by a bound in this associated function
615 |     where
616 |         Tracer: PreSampledTracer + otel::Tracer + 'static,
    |                                    ^^^^^^^^^^^^ required by this bound in `OpenTelemetryLayer::<S, T>::with_tracer`

error[E0277]: the trait bound `SdkTracer: PreSampledTracer` is not satisfied. 
              This usually happens when wrong version of `opentelemetry` is used.
    --> examples/basic.rs:20:47
     |
20   |     let subscriber = Registry::default().with(telemetry);
     |                                          ---- ^^^^^^^^^ the trait bound `SdkTracer: PreSampledTracer` is not satisfied. This usually happens when wrong version of `opentelemetry` is used.
     |                                          |
     |                                          required by a bound introduced by this call
     |
     = help: the trait `PreSampledTracer` is not implemented for `SdkTracer`
     = note: Make sure you're using correct `opentelemetry` and `opentelemetry_sdk` versions compatible with this `tracing-opentelemetry`. The `opentelemetry` versions are usually one version lower than `tracing-opentelemetry`.
     = help: the following other types implement trait `PreSampledTracer`:
               opentelemetry::trace::noop::NoopTracer
               opentelemetry_sdk::trace::tracer::SdkTracer
     = note: required for `OpenTelemetryLayer<Registry, SdkTracer>` to implement `__tracing_subscriber_Layer<Registry>`
note: required by a bound in `with`
    --> /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-subscriber-0.3.0/src/layer/mod.rs:1065:12
     |
1063 |     fn with<L>(self, layer: L) -> Layered<L, Self>
     |        ---- required by a bound in this associated function
1064 |     where
1065 |         L: Layer<Self>,
     |            ^^^^^^^^^^^ required by this bound in `__tracing_subscriber_SubscriberExt::with`

error[E0277]: the trait bound `SdkTracer: opentelemetry::trace::tracer::Tracer` is not satisfied
    --> examples/basic.rs:20:47
     |
20   |     let subscriber = Registry::default().with(telemetry);
     |                                          ---- ^^^^^^^^^ the trait `opentelemetry::trace::tracer::Tracer` is not implemented for `SdkTracer`
     |                                          |
     |                                          required by a bound introduced by this call
     |
note: there are multiple different versions of crate `opentelemetry` in the dependency graph
    --> /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry-0.30.0/src/trace/tracer.rs:121:1
     |
121  | pub trait Tracer {
     | ^^^^^^^^^^^^^^^^ this is the required trait
     |
    ::: examples/basic.rs:1:5
     |
1    | use opentelemetry_29::trace::TracerProvider as _;
     |     ---------------- one version of crate `opentelemetry` used here, as a direct dependency of the current crate
...
16   |     let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
     |                     --------------------- one version of crate `opentelemetry` used here, as a dependency of crate `tracing_opentelemetry`
     |
    ::: /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry_sdk-0.29.0/src/trace/tracer.rs:23:1
     |
23   | pub struct SdkTracer {
     | -------------------- this type doesn't implement the required trait
     |
    ::: /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry_sdk-0.30.0/src/trace/tracer.rs:23:1
     |
23   | pub struct SdkTracer {
     | -------------------- this type implements the required trait
     |
    ::: /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry-0.29.1/src/global/trace.rs:12:1
     |
12   | pub trait ObjectSafeSpan {
     | ------------------------ this is the found trait
     = note: two types coming from two different versions of the same crate are different types even if they look the same
     = help: you can use `cargo tree` to explore your dependency tree
     = note: required for `OpenTelemetryLayer<Registry, SdkTracer>` to implement `__tracing_subscriber_Layer<Registry>`
note: required by a bound in `with`
    --> /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-subscriber-0.3.0/src/layer/mod.rs:1065:12
     |
1063 |     fn with<L>(self, layer: L) -> Layered<L, Self>
     |        ---- required by a bound in this associated function
1064 |     where
1065 |         L: Layer<Self>,
     |            ^^^^^^^^^^^ required by this bound in `__tracing_subscriber_SubscriberExt::with`

error[E0277]: the trait bound `SdkTracer: PreSampledTracer` is not satisfied. 
              This usually happens when wrong version of `opentelemetry` is used.
  --> examples/basic.rs:23:39
   |
23 |     tracing::subscriber::with_default(subscriber, || {
   |     --------------------------------- ^^^^^^^^^^ the trait bound `SdkTracer: PreSampledTracer` is not satisfied. This usually happens when wrong version of `opentelemetry` is used.
   |     |
   |     required by a bound introduced by this call
   |
   = help: the trait `PreSampledTracer` is not implemented for `SdkTracer`
   = note: Make sure you're using correct `opentelemetry` and `opentelemetry_sdk` versions compatible with this `tracing-opentelemetry`. The `opentelemetry` versions are usually one version lower than `tracing-opentelemetry`.
   = help: the following other types implement trait `PreSampledTracer`:
             opentelemetry::trace::noop::NoopTracer
             opentelemetry_sdk::trace::tracer::SdkTracer
   = note: required for `OpenTelemetryLayer<Registry, SdkTracer>` to implement `__tracing_subscriber_Layer<Registry>`
   = note: required for `Layered<OpenTelemetryLayer<Registry, SdkTracer>, Registry>` to implement `tracing::Subscriber`
note: required by a bound in `tracing::subscriber::with_default`
  --> /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-0.1.40/src/subscriber.rs:22:8
   |
20 | pub fn with_default<T, S>(subscriber: S, f: impl FnOnce() -> T) -> T
   |        ------------ required by a bound in this function
21 | where
22 |     S: Subscriber + Send + Sync + 'static,
   |        ^^^^^^^^^^ required by this bound in `with_default`

error[E0277]: the trait bound `SdkTracer: opentelemetry::trace::tracer::Tracer` is not satisfied
   --> examples/basic.rs:23:39
    |
23  |     tracing::subscriber::with_default(subscriber, || {
    |     --------------------------------- ^^^^^^^^^^ the trait `opentelemetry::trace::tracer::Tracer` is not implemented for `SdkTracer`
    |     |
    |     required by a bound introduced by this call
    |
note: there are multiple different versions of crate `opentelemetry` in the dependency graph
   --> /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry-0.30.0/src/trace/tracer.rs:121:1
    |
121 | pub trait Tracer {
    | ^^^^^^^^^^^^^^^^ this is the required trait
    |
   ::: examples/basic.rs:1:5
    |
1   | use opentelemetry_29::trace::TracerProvider as _;
    |     ---------------- one version of crate `opentelemetry` used here, as a direct dependency of the current crate
...
16  |     let telemetry = tracing_opentelemetry::layer().with_tracer(tracer);
    |                     --------------------- one version of crate `opentelemetry` used here, as a dependency of crate `tracing_opentelemetry`
    |
   ::: /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry_sdk-0.29.0/src/trace/tracer.rs:23:1
    |
23  | pub struct SdkTracer {
    | -------------------- this type doesn't implement the required trait
    |
   ::: /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry_sdk-0.30.0/src/trace/tracer.rs:23:1
    |
23  | pub struct SdkTracer {
    | -------------------- this type implements the required trait
    |
   ::: /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/opentelemetry-0.29.1/src/global/trace.rs:12:1
    |
12  | pub trait ObjectSafeSpan {
    | ------------------------ this is the found trait
    = note: two types coming from two different versions of the same crate are different types even if they look the same
    = help: you can use `cargo tree` to explore your dependency tree
    = note: required for `OpenTelemetryLayer<Registry, SdkTracer>` to implement `__tracing_subscriber_Layer<Registry>`
    = note: required for `Layered<OpenTelemetryLayer<Registry, SdkTracer>, Registry>` to implement `tracing::Subscriber`
note: required by a bound in `tracing::subscriber::with_default`
   --> /home/mladedav/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/tracing-0.1.40/src/subscriber.rs:22:8
    |
20  | pub fn with_default<T, S>(subscriber: S, f: impl FnOnce() -> T) -> T
    |        ------------ required by a bound in this function
21  | where
22  |     S: Subscriber + Send + Sync + 'static,
    |        ^^^^^^^^^^ required by this bound in `with_default`

For more information about this error, try `rustc --explain E0277`.
error: could not compile `tracing-opentelemetry` (example "basic") due to 6 previous errors

```

</p>
</details> 