### PR TITLE
chore!: remove metrics feature gate

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Unreleased
 
+### Removed
+
+- Feature `metrics_gauge_unstable` since metrics gauge are stable in upstream now.
+
 # 0.31.0 (June 2, 2025)
 
 ### Breaking Changes

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,8 +19,6 @@ rust-version = "1.75.0"
 default = ["tracing-log", "metrics"]
 # Enables support for exporting OpenTelemetry metrics
 metrics = ["opentelemetry/metrics","opentelemetry_sdk/metrics", "smallvec"]
-# Enables experimental support for OpenTelemetry gauge metrics
-metrics_gauge_unstable = []
 
 [dependencies]
 opentelemetry = { version = "0.30.0", default-features = false, features = ["trace"] }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -2,10 +2,8 @@ use std::{collections::HashMap, fmt, sync::RwLock};
 use tracing::{field::Visit, Subscriber};
 use tracing_core::{Field, Interest, Metadata};
 
-#[cfg(feature = "metrics_gauge_unstable")]
-use opentelemetry::metrics::Gauge;
 use opentelemetry::{
-    metrics::{Counter, Histogram, Meter, MeterProvider, UpDownCounter},
+    metrics::{Counter, Gauge, Histogram, Meter, MeterProvider, UpDownCounter},
     InstrumentationScope, KeyValue, Value,
 };
 use tracing_subscriber::{
@@ -23,7 +21,6 @@ const INSTRUMENTATION_LIBRARY_NAME: &str = "tracing/tracing-opentelemetry";
 const METRIC_PREFIX_MONOTONIC_COUNTER: &str = "monotonic_counter.";
 const METRIC_PREFIX_COUNTER: &str = "counter.";
 const METRIC_PREFIX_HISTOGRAM: &str = "histogram.";
-#[cfg(feature = "metrics_gauge_unstable")]
 const METRIC_PREFIX_GAUGE: &str = "gauge.";
 
 const I64_MAX: u64 = i64::MAX as u64;
@@ -36,11 +33,8 @@ pub(crate) struct Instruments {
     f64_up_down_counter: MetricsMap<UpDownCounter<f64>>,
     u64_histogram: MetricsMap<Histogram<u64>>,
     f64_histogram: MetricsMap<Histogram<f64>>,
-    #[cfg(feature = "metrics_gauge_unstable")]
     u64_gauge: MetricsMap<Gauge<u64>>,
-    #[cfg(feature = "metrics_gauge_unstable")]
     i64_gauge: MetricsMap<Gauge<i64>>,
-    #[cfg(feature = "metrics_gauge_unstable")]
     f64_gauge: MetricsMap<Gauge<f64>>,
 }
 
@@ -54,11 +48,8 @@ pub(crate) enum InstrumentType {
     UpDownCounterF64(f64),
     HistogramU64(u64),
     HistogramF64(f64),
-    #[cfg(feature = "metrics_gauge_unstable")]
     GaugeU64(u64),
-    #[cfg(feature = "metrics_gauge_unstable")]
     GaugeI64(i64),
-    #[cfg(feature = "metrics_gauge_unstable")]
     GaugeF64(f64),
 }
 
@@ -142,7 +133,6 @@ impl Instruments {
                     |rec| rec.record(value, attributes),
                 );
             }
-            #[cfg(feature = "metrics_gauge_unstable")]
             InstrumentType::GaugeU64(value) => {
                 update_or_insert(
                     &self.u64_gauge,
@@ -151,7 +141,6 @@ impl Instruments {
                     |rec| rec.record(value, attributes),
                 );
             }
-            #[cfg(feature = "metrics_gauge_unstable")]
             InstrumentType::GaugeI64(value) => {
                 update_or_insert(
                     &self.i64_gauge,
@@ -160,7 +149,6 @@ impl Instruments {
                     |rec| rec.record(value, attributes),
                 );
             }
-            #[cfg(feature = "metrics_gauge_unstable")]
             InstrumentType::GaugeF64(value) => {
                 update_or_insert(
                     &self.f64_gauge,
@@ -185,7 +173,6 @@ impl Visit for MetricVisitor<'_> {
     }
 
     fn record_u64(&mut self, field: &Field, value: u64) {
-        #[cfg(feature = "metrics_gauge_unstable")]
         if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_GAUGE) {
             self.visited_metrics
                 .push((metric_name, InstrumentType::GaugeU64(value)));
@@ -216,7 +203,6 @@ impl Visit for MetricVisitor<'_> {
     }
 
     fn record_f64(&mut self, field: &Field, value: f64) {
-        #[cfg(feature = "metrics_gauge_unstable")]
         if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_GAUGE) {
             self.visited_metrics
                 .push((metric_name, InstrumentType::GaugeF64(value)));
@@ -238,7 +224,6 @@ impl Visit for MetricVisitor<'_> {
     }
 
     fn record_i64(&mut self, field: &Field, value: i64) {
-        #[cfg(feature = "metrics_gauge_unstable")]
         if let Some(metric_name) = field.name().strip_prefix(METRIC_PREFIX_GAUGE) {
             self.visited_metrics
                 .push((metric_name, InstrumentType::GaugeI64(value)));
@@ -427,7 +412,6 @@ impl MetricsFilter {
                     return true;
                 }
 
-                #[cfg(feature = "metrics_gauge_unstable")]
                 if name.starts_with(METRIC_PREFIX_GAUGE) {
                     return true;
                 }

--- a/tests/metrics_publishing.rs
+++ b/tests/metrics_publishing.rs
@@ -112,7 +112,6 @@ async fn f64_up_down_counter_is_exported() {
     exporter.export().unwrap();
 }
 
-#[cfg(feature = "metrics_gauge_unstable")]
 #[tokio::test]
 async fn u64_gauge_is_exported() {
     let (subscriber, exporter) =
@@ -126,7 +125,6 @@ async fn u64_gauge_is_exported() {
     exporter.export().unwrap();
 }
 
-#[cfg(feature = "metrics_gauge_unstable")]
 #[tokio::test]
 async fn f64_gauge_is_exported() {
     let (subscriber, exporter) =
@@ -140,7 +138,6 @@ async fn f64_gauge_is_exported() {
     exporter.export().unwrap();
 }
 
-#[cfg(feature = "metrics_gauge_unstable")]
 #[tokio::test]
 async fn i64_gauge_is_exported() {
     let (subscriber, exporter) =
@@ -302,7 +299,6 @@ async fn f64_up_down_counter_with_attributes_is_exported() {
     exporter.export().unwrap();
 }
 
-#[cfg(feature = "metrics_gauge_unstable")]
 #[tokio::test]
 async fn f64_gauge_with_attributes_is_exported() {
     let (subscriber, exporter) = init_subscriber(
@@ -332,7 +328,6 @@ async fn f64_gauge_with_attributes_is_exported() {
     exporter.export().unwrap();
 }
 
-#[cfg(feature = "metrics_gauge_unstable")]
 #[tokio::test]
 async fn u64_gauge_with_attributes_is_exported() {
     let (subscriber, exporter) = init_subscriber(
@@ -362,7 +357,6 @@ async fn u64_gauge_with_attributes_is_exported() {
     exporter.export().unwrap();
 }
 
-#[cfg(feature = "metrics_gauge_unstable")]
 #[tokio::test]
 async fn i64_gauge_with_attributes_is_exported() {
     let (subscriber, exporter) = init_subscriber(


### PR DESCRIPTION
## Motivation

The upstream feature has been stabilized so there is no reason for use to hide the functionality behind an "unstable" feature.

## Solution

Remove the cargo feature.