### PR TITLE
Fix: remove Lazy for thread_local static

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,6 @@ tracing = { version = "0.1.35", default-features = false, features = ["std"] }
 tracing-core = "0.1.28"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = ["registry", "std"] }
 tracing-log = { version = "0.2.0", default-features = false, optional = true }
-once_cell = "1.13.0"
 rustversion = "1.0.9"
 smallvec = { version = "1.0", optional = true }
 


### PR DESCRIPTION
As `thread_local` statics are already lazily initialized on first access, there is no need to use a Lazy initializer on top of that.

This PR removes that usage and the associated dependency on `once_cell`.