### PR TITLE
chore: delete removed docs.rs feature

### DIFF
--- a/src/layer.rs
+++ b/src/layer.rs
@@ -711,9 +711,8 @@ where
         }
     }
 
-    /// Sets whether or not an event considered for exception mapping (see [`OpenTelemetryLayer::with_error_recording`])
+    /// Sets whether or not an event considered for exception mapping (see [`OpenTelemetryLayer::with_error_records_to_exceptions`])
     /// should be propagated to the span status error description.
-    ///
     ///
     /// By default, these events do set the span status error description.
     pub fn with_error_events_to_status(self, error_events_to_status: bool) -> Self {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -102,7 +102,7 @@
 #![cfg_attr(
     docsrs,
     // Allows displaying cfgs/feature flags in the documentation.
-    feature(doc_cfg, doc_auto_cfg),
+    feature(doc_cfg),
     // Allows adding traits to RustDoc's list of "notable traits"
     feature(doc_notable_trait),
     // Fail the docs build if any intra-docs links are broken


### PR DESCRIPTION
## Motivation

The feature has been removed and builds on docs.rs are failing if it's left there.

## Solution

Remove the removed featue.