### PR TITLE
chore: remove thiserror and unused dependencies

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,15 +34,12 @@ tracing-subscriber = { version = "0.3.0", default-features = false, features = [
     "std",
 ] }
 tracing-log = { version = "0.2.0", default-features = false, optional = true }
-rustversion = "1.0.9"
 smallvec = { version = "1.0", optional = true }
-thiserror = { version = "2", default-features = false }
 
 # Fix minimal-versions
 lazy_static = { version = "1.0.2", optional = true }
 
 [dev-dependencies]
-async-trait = "0.1.56"
 criterion = { version = "0.5.1", default-features = false, features = [
     "html_reports",
 ] }
@@ -61,9 +58,7 @@ opentelemetry-otlp = { version = "0.31.0", features = [
 opentelemetry-semantic-conventions = { version = "0.31.0", features = [
     "semconv_experimental",
 ] }
-futures-util = { version = "0.3.17", default-features = false }
 tokio = { version = "1", features = ["full"] }
-tokio-stream = "0.1"
 tracing = { version = "0.1.35", default-features = false, features = [
     "std",
     "attributes",

--- a/src/span_ext.rs
+++ b/src/span_ext.rs
@@ -5,8 +5,7 @@ use opentelemetry::{
     trace::{SpanContext, Status, TraceContextExt},
     Context, Key, KeyValue, Value,
 };
-use std::{borrow::Cow, time::SystemTime};
-use thiserror::Error;
+use std::{borrow::Cow, fmt, time::SystemTime};
 
 /// Utility functions to allow tracing [`Span`]s to accept and return
 /// [OpenTelemetry] [`Context`]s.
@@ -227,27 +226,42 @@ pub trait OpenTelemetrySpanExt {
 }
 
 /// An error returned if [`OpenTelemetrySpanExt::set_parent`] could not set the parent.
-#[derive(Error, Debug)]
+#[derive(Debug)]
 pub enum SetParentError {
     /// The layer could not be found and therefore the action could not be carried out. This can
     /// happen with some advanced layers that do not handle downcasting well, for example
     /// [`tracing_subscriber::reload::Layer`].
-    #[error("OpenTelemetry layer not found")]
     LayerNotFound,
 
     /// The span has been already started.
     ///
     /// Someone already called a context-starting method such as [`OpenTelemetrySpanExt::context`]
     /// or the span has been entered and automatic context starting was not configured out.
-    #[error("Span has already been started, cannot set parent")]
     AlreadyStarted,
 
     /// The span is filtered out by tracing filters.
     ///
     /// If the filtered out span had children, they will not be connected to the parent span either.
-    #[error("Span disabled")]
     SpanDisabled,
 }
+
+impl fmt::Display for SetParentError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SetParentError::LayerNotFound => {
+                write!(f, "OpenTelemetry layer not found")
+            }
+            SetParentError::AlreadyStarted => {
+                write!(f, "Span has already been started, cannot set parent")
+            }
+            SetParentError::SpanDisabled => {
+                write!(f, "Span disabled")
+            }
+        }
+    }
+}
+
+impl std::error::Error for SetParentError {}
 
 impl OpenTelemetrySpanExt for tracing::Span {
     fn set_parent(&self, cx: Context) -> Result<(), SetParentError> {


### PR DESCRIPTION
## Motivation

Was aiming to reduce `syn` usage in my dependency tree, and noticed a fairly unnecessary use of `thiserror` here. Also noticed a handful of unused deps, thanks to `cargo-shear`.

## Solution

Removal of the unused deps, and replacing `thiserror` with a manual implementation.
