### PR TITLE
Remove unwanted dependency on opentelemetry sdk crate

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,15 +18,13 @@ rust-version = "1.75.0"
 [features]
 default = ["tracing-log", "metrics"]
 # Enables support for exporting OpenTelemetry metrics
-metrics = ["opentelemetry/metrics", "opentelemetry_sdk/metrics", "smallvec"]
+metrics = ["opentelemetry/metrics", "smallvec"]
 
 [dependencies]
 opentelemetry = { version = "0.31.0", default-features = false, features = [
     "trace",
 ] }
-opentelemetry_sdk = { version = "0.31.0", default-features = false, features = [
-    "trace",
-] }
+
 tracing = { version = "0.1.35", default-features = false, features = ["std"] }
 tracing-core = "0.1.28"
 tracing-subscriber = { version = "0.3.0", default-features = false, features = [
@@ -46,7 +44,6 @@ criterion = { version = "0.5.1", default-features = false, features = [
 opentelemetry = { version = "0.31.0", features = ["trace", "metrics"] }
 opentelemetry_sdk = { version = "0.31.0", default-features = false, features = [
     "trace",
-    "rt-tokio",
     "experimental_metrics_custom_reader",
     "testing",
 ] }

--- a/src/layer/filtered.rs
+++ b/src/layer/filtered.rs
@@ -144,6 +144,7 @@ where
                 OtelDataState::Builder {
                     builder,
                     parent_cx: _,
+                    ..
                 } => {
                     builder.attributes.get_or_insert(Vec::new()).push(key_value);
                 }


### PR DESCRIPTION
Remove dependency on `opentelemetry_sdk` crate. This is not required as the layer operates on constructs available in `opentelemetry` crate itself. Tests and examples continue to rely on `opentelemetry_sdk`.

## Motivation

Removes unwanted dependency.

