### PR TITLE
fix: avoid deadlock when entering a span

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ bench = false
 
 [lints.rust]
 unnameable_types = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(__reentrant_tracing_test)'] }
 
 [[bench]]
 name = "trace"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -79,6 +79,7 @@ bench = false
 
 [lints.rust]
 unnameable_types = "warn"
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(reentrant_tracing_test)'] }
 
 [[bench]]
 name = "trace"

--- a/examples/otel_context.rs
+++ b/examples/otel_context.rs
@@ -75,45 +75,38 @@ where
         &self,
         attrs: &tracing::span::Attributes<'_>,
         id: &tracing::span::Id,
-        ctx: Context<'_, S>,
+        _ctx: Context<'_, S>,
     ) {
         let Some(weak_dispatch) = self.dispatch.get() else {
             return;
         };
 
-        // Get the span reference and extract OpenTelemetry context
-        if let Some(span_ref) = ctx.span(id) {
-            // This is the key functionality: using OpenTelemetryContext
-            // to extract the OpenTelemetry context from span extensions
-            let mut extensions = span_ref.extensions_mut();
-            if let Some(dispatch) = weak_dispatch.upgrade() {
-                if let Some(otel_context) = get_otel_context(&mut extensions, &dispatch) {
-                    self.analyze_span_context(attrs.metadata().name(), &otel_context);
-                } else {
-                    println!(
-                        "⚠️  Could not extract OpenTelemetry context for span '{}'",
-                        attrs.metadata().name()
-                    );
-                }
+        // This is the key functionality: using OpenTelemetryContext
+        // to extract the OpenTelemetry context from span extensions
+        if let Some(dispatch) = weak_dispatch.upgrade() {
+            if let Some(otel_context) = get_otel_context(id, &dispatch) {
+                self.analyze_span_context(attrs.metadata().name(), &otel_context);
+            } else {
+                println!(
+                    "⚠️  Could not extract OpenTelemetry context for span '{}'",
+                    attrs.metadata().name()
+                );
             }
         }
     }
 
-    fn on_enter(&self, id: &tracing::span::Id, ctx: Context<'_, S>) {
+    fn on_enter(&self, id: &tracing::span::Id, _ctx: Context<'_, S>) {
         if let Some(weak_dispatch) = self.dispatch.get() {
-            if let Some(span_ref) = ctx.span(id) {
-                let mut extensions = span_ref.extensions_mut();
-                if let Some(dispatch) = weak_dispatch.upgrade() {
-                    if let Some(otel_context) = get_otel_context(&mut extensions, &dispatch) {
-                        let span = otel_context.span();
-                        let span_context = span.span_context();
-                        if span_context.is_valid() {
-                            println!(
-                                "📍 Entering span with trace_id: {:032x}, span_id: {:016x}",
-                                span_context.trace_id(),
-                                span_context.span_id()
-                            );
-                        }
+            if let Some(dispatch) = weak_dispatch.upgrade() {
+                if let Some(otel_context) = get_otel_context(id, &dispatch) {
+                    let span = otel_context.span();
+                    let span_context = span.span_context();
+                    if span_context.is_valid() {
+                        println!(
+                            "📍 Entering span with trace_id: {:032x}, span_id: {:016x}",
+                            span_context.trace_id(),
+                            span_context.span_id()
+                        );
                     }
                 }
             }

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,12 +1,13 @@
 use crate::stack::IdValueStack;
-use crate::{OtelData, OtelDataState};
+use crate::{OtelData, OtelDataLock, OtelDataState};
 pub use filtered::FilteredOpenTelemetryLayer;
 use opentelemetry::ContextGuard;
 use opentelemetry::{
     trace::{self as otel, noop, Span, SpanBuilder, SpanKind, Status, TraceContextExt},
     Context as OtelContext, Key, KeyValue, StringValue, Value,
 };
-use std::cell::RefCell;
+use std::cell::{Cell, RefCell};
+use std::sync::Arc;
 use std::thread;
 #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
 use std::time::Instant;
@@ -19,7 +20,7 @@ use tracing_core::{field, Event, Subscriber};
 use tracing_log::NormalizeEvent;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::layer::Filter;
-use tracing_subscriber::registry::{ExtensionsMut, LookupSpan};
+use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::Layer;
 #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use web_time::Instant;
@@ -35,6 +36,10 @@ const SPAN_EVENT_COUNT_FIELD: &str = "otel.tracing_event_count";
 const EVENT_EXCEPTION_NAME: &str = "exception";
 const FIELD_EXCEPTION_MESSAGE: &str = "exception.message";
 const FIELD_EXCEPTION_STACKTRACE: &str = "exception.stacktrace";
+
+std::thread_local! {
+    static INSIDE_TRACING: Cell<bool> = const { Cell::new(false) };
+}
 
 /// An [OpenTelemetry] propagation layer for use in a project that uses
 /// [tracing].
@@ -125,7 +130,7 @@ pub(crate) struct WithContext {
     ///
     #[allow(clippy::type_complexity)]
     pub(crate) with_activated_otel_context:
-        fn(&tracing::Dispatch, &mut ExtensionsMut<'_>, f: &mut dyn FnMut(&OtelContext)),
+        fn(&tracing::Dispatch, &span::Id, f: &mut dyn FnMut(&OtelContext)),
 }
 
 impl WithContext {
@@ -164,10 +169,10 @@ impl WithContext {
     pub(crate) fn with_activated_otel_context(
         &self,
         dispatch: &tracing::Dispatch,
-        extensions: &mut ExtensionsMut<'_>,
+        id: &span::Id,
         mut f: impl FnMut(&OtelContext),
     ) {
-        (self.with_activated_otel_context)(dispatch, extensions, &mut f)
+        (self.with_activated_otel_context)(dispatch, id, &mut f)
     }
 }
 
@@ -919,11 +924,11 @@ where
             //
             // In these case, we prefer to emit a smaller span tree instead of panicking.
             if let Some(span) = ctx.span(parent) {
-                let mut extensions = span.extensions_mut();
-                if let Some(otel_data) = extensions.get_mut::<OtelData>() {
+                let extensions = span.extensions();
+                if let Some(otel_data) = extensions.get::<OtelDataLock>() {
                     // If the parent span has a span builder the parent span should be started
                     // so we get a proper context with the parent span.
-                    return self.with_started_cx(otel_data, &|cx| cx.clone());
+                    return self.with_started_cx(&mut otel_data.lock(), &|cx| cx.clone());
                 }
             }
         }
@@ -938,10 +943,10 @@ where
                 // we should use the current tracing context
                 ctx.lookup_current()
                     .and_then(|span| {
-                        let mut extensions = span.extensions_mut();
+                        let extensions = span.extensions();
                         extensions
-                            .get_mut::<OtelData>()
-                            .map(|data| self.with_started_cx(data, &|cx| cx.clone()))
+                            .get::<OtelDataLock>()
+                            .map(|data| self.with_started_cx(&mut data.lock(), &|cx| cx.clone()))
                     })
                     .unwrap_or_else(OtelContext::current)
             }
@@ -970,9 +975,9 @@ where
             .span(id)
             .expect("registry should have a span for the current ID");
 
-        let mut extensions = span.extensions_mut();
-        if let Some(otel_data) = extensions.get_mut::<OtelData>() {
-            f(otel_data);
+        let otel_data = span.extensions().get::<OtelDataLock>().cloned();
+        if let Some(otel_data) = otel_data {
+            f(&mut otel_data.lock());
         }
     }
 
@@ -993,19 +998,29 @@ where
         id: &span::Id,
         f: &mut dyn FnMut(&mut OtelData),
     ) {
+        let layer = dispatch
+            .downcast_ref::<OpenTelemetryLayer<S, T>>()
+            .expect("layer should downcast to expected type; this is a bug!");
+
         let subscriber = dispatch
             .downcast_ref::<S>()
             .expect("subscriber should downcast to expected type; this is a bug!");
+
         let span = subscriber
             .span(id)
             .expect("registry should have a span for the current ID");
 
-        let mut extensions = span.extensions_mut();
+        let otel_data = span.extensions().get::<OtelDataLock>().cloned();
 
-        Self::get_activated_context_extensions(dispatch, &mut extensions, f)
+        if let Some(otel_data) = otel_data {
+            let mut otel_data = otel_data.lock();
+            // Activate the context
+            layer.start_cx(&mut otel_data);
+            f(&mut otel_data);
+        }
     }
 
-    /// Retrieves the activated OpenTelemetry context from a span's extensions and passes it
+    /// Retrieves the activated OpenTelemetry context from a span's ID and passes it
     /// to the provided function.
     ///
     /// This method activates the context and extracts the current OTel `Context` from the
@@ -1015,38 +1030,18 @@ where
     /// # Parameters
     ///
     /// * `dispatch` - The tracing dispatch to downcast to the `OpenTelemetryLayer`
-    /// * `extensions` - Mutable reference to the span's extensions containing `OtelData`
+    /// * `id` - The span ID to look up in the registry
     /// * `f` - The closure to invoke with a reference to the OTel `Context`
     fn get_activated_otel_context(
         dispatch: &tracing::Dispatch,
-        extensions: &mut ExtensionsMut<'_>,
+        span: &span::Id,
         f: &mut dyn FnMut(&OtelContext),
     ) {
-        Self::get_activated_context_extensions(
-            dispatch,
-            extensions,
-            &mut |otel_data: &mut OtelData| {
-                if let OtelDataState::Context { current_cx } = &otel_data.state {
-                    f(current_cx)
-                }
-            },
-        );
-    }
-
-    fn get_activated_context_extensions(
-        dispatch: &tracing::Dispatch,
-        extensions: &mut ExtensionsMut<'_>,
-        f: &mut dyn FnMut(&mut OtelData),
-    ) {
-        let layer = dispatch
-            .downcast_ref::<OpenTelemetryLayer<S, T>>()
-            .expect("layer should downcast to expected type; this is a bug!");
-
-        if let Some(otel_data) = extensions.get_mut::<OtelData>() {
-            // Activate the context
-            layer.start_cx(otel_data);
-            f(otel_data);
-        }
+        Self::get_activated_context(dispatch, span, &mut |otel_data: &mut OtelData| {
+            if let OtelDataState::Context { current_cx } = &otel_data.state {
+                f(current_cx)
+            }
+        });
     }
 
     fn extra_span_attrs(&self) -> usize {
@@ -1079,9 +1074,16 @@ where
             status,
         } = take(&mut otel_data.state)
         {
+            // We purposefully disable all tracing inside this call. Whoever called this is holding
+            // a lock on `OtelData` and this is not reentrant.
+            INSIDE_TRACING.with(|inside| inside.set(true));
+            #[cfg(all(test, __reentrant_tracing_test))]
+            tracing::info!("This should not deadlock...");
             let mut span = builder.start_with_context(&self.tracer, &parent_cx);
             span.set_status(status);
             let current_cx = parent_cx.with_span(span);
+            INSIDE_TRACING.with(|inside| inside.set(false));
+
             otel_data.state = OtelDataState::Context { current_cx };
         }
     }
@@ -1089,7 +1091,14 @@ where
     fn with_started_cx<U>(&self, otel_data: &mut OtelData, f: &dyn Fn(&OtelContext) -> U) -> U {
         self.start_cx(otel_data);
         match &otel_data.state {
-            OtelDataState::Context { current_cx, .. } => f(current_cx),
+            OtelDataState::Context { current_cx, .. } => {
+                INSIDE_TRACING.with(|inside| inside.set(true));
+                #[cfg(all(test, __reentrant_tracing_test))]
+                tracing::info!("This should not deadlock...");
+                let result = f(current_cx);
+                INSIDE_TRACING.with(|inside| inside.set(false));
+                result
+            }
             _ => panic!("OtelDataState should be a Context after starting it; this is a bug!"),
         }
     }
@@ -1184,14 +1193,14 @@ where
 
         let mut status = Status::Unset;
         updates.update(&mut builder, &mut status);
-        extensions.insert(OtelData {
+        extensions.insert(OtelDataLock::new(OtelData {
             state: OtelDataState::Builder {
                 builder,
                 parent_cx,
                 status,
             },
             end_time: None,
-        });
+        }));
     }
 
     fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
@@ -1200,11 +1209,13 @@ where
         }
 
         let span = ctx.span(id).expect("Span not found, this is a bug");
-        let mut extensions = span.extensions_mut();
 
         if self.context_activation {
-            if let Some(otel_data) = extensions.get_mut::<OtelData>() {
-                self.with_started_cx(otel_data, &|cx| {
+            // We must not hold the extensions when starting the context to avoid potential
+            // deadlocks.
+            let otel_data = span.extensions().get::<OtelDataLock>().cloned();
+            if let Some(otel_data) = otel_data {
+                self.with_started_cx(&mut otel_data.lock(), &|cx| {
                     let guard = cx.clone().attach();
                     GUARD_STACK.with(|stack| stack.borrow_mut().push(id.clone(), guard));
                 });
@@ -1214,6 +1225,8 @@ where
                 return;
             }
         }
+
+        let mut extensions = span.extensions_mut();
 
         if let Some(timings) = extensions.get_mut::<Timings>() {
             if timings.entered_count == 0 {
@@ -1229,8 +1242,11 @@ where
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
 
-        if let Some(otel_data) = extensions.get_mut::<OtelData>() {
-            otel_data.end_time = Some(crate::time::now());
+        // We don't need mutable access to this but we're taking mutable extensions for timings
+        // anyway so let's use it instead of locking it twice. This is ok because here we will not
+        // start the opentelemetry context nor will we call any other code that might use tracing.
+        if let Some(otel_data) = extensions.get_mut::<OtelDataLock>() {
+            otel_data.lock().end_time = Some(crate::time::now());
             if self.context_activation {
                 GUARD_STACK.with(|stack| stack.borrow_mut().pop(id));
             }
@@ -1260,9 +1276,9 @@ where
             span_builder_updates: &mut updates,
             sem_conv_config: self.sem_conv_config,
         });
-        let mut extensions = span.extensions_mut();
-        if let Some(otel_data) = extensions.get_mut::<OtelData>() {
-            match &mut otel_data.state {
+        let extensions = span.extensions();
+        if let Some(otel_data) = extensions.get::<OtelDataLock>() {
+            match &mut otel_data.lock().state {
                 OtelDataState::Builder {
                     builder, status, ..
                 } => {
@@ -1279,8 +1295,8 @@ where
 
     fn on_follows_from(&self, id: &Id, follows: &Id, ctx: Context<S>) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
-        let mut extensions = span.extensions_mut();
-        let Some(data) = extensions.get_mut::<OtelData>() else {
+        let otel_data = span.extensions().get::<OtelDataLock>().cloned();
+        let Some(data) = otel_data else {
             return; // The span must already have been closed by us
         };
 
@@ -1288,13 +1304,22 @@ where
         // in which case we just drop the data, as opposed to panicking. This
         // uses the same reasoning as `parent_context` above.
         if let Some(follows_span) = ctx.span(follows) {
-            let mut follows_extensions = follows_span.extensions_mut();
-            let Some(follows_data) = follows_extensions.get_mut::<OtelData>() else {
+            let follows_extensions = follows_span.extensions();
+            let follows_otel_data = follows_extensions.get::<OtelDataLock>();
+            let Some(follows_data) = follows_otel_data else {
                 return; // The span must already have been closed by us
             };
+
+            let follows_data = follows_data.clone();
+            let mut follows_locked = follows_data.lock();
+            // We drop the extensions lock only after locking the inside. This is because we want to
+            // hinder potential `close` on the follows span. If we hold one or the other lock, the
+            // close implementation cannot progress to remove the span.
+            drop(follows_extensions);
+
             let follows_context =
-                self.with_started_cx(follows_data, &|cx| cx.span().span_context().clone());
-            match &mut data.state {
+                self.with_started_cx(&mut follows_locked, &|cx| cx.span().span_context().clone());
+            match &mut data.lock().state {
                 OtelDataState::Builder { builder, .. } => {
                     if let Some(ref mut links) = builder.links {
                         links.push(otel::Link::with_context(follows_context));
@@ -1318,6 +1343,10 @@ where
     /// [`ERROR`]: tracing::Level::ERROR
     /// [`Error`]: opentelemetry::trace::StatusCode::Error
     fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        if INSIDE_TRACING.with(|inside| inside.get()) {
+            // Ignore reentrant calls.
+            return;
+        }
         // Ignore events that are not in the context of a span
         if let Some(span) = event.parent().and_then(|id| ctx.span(id)).or_else(|| {
             event
@@ -1375,9 +1404,9 @@ where
                 otel_event.name = std::borrow::Cow::Borrowed(event.metadata().name());
             }
 
-            let mut extensions = span.extensions_mut();
+            let otel_data = span.extensions().get::<OtelDataLock>().cloned();
 
-            if let Some(otel_data) = extensions.get_mut::<OtelData>() {
+            if let Some(otel_data) = otel_data {
                 if self.location {
                     #[cfg(not(feature = "tracing-log"))]
                     let normalized_meta: Option<tracing_core::Metadata<'_>> = None;
@@ -1409,7 +1438,7 @@ where
                     }
                 }
 
-                match &mut otel_data.state {
+                match &mut otel_data.lock().state {
                     OtelDataState::Builder {
                         builder, status, ..
                     } => {
@@ -1449,17 +1478,36 @@ where
     fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
         let span = ctx.span(&id).expect("Span not found, this is a bug");
         // Now get mutable extensions for removal
-        let (otel_data, timings) = {
+        let (otel_data_lock, timings) = {
             let mut extensions = span.extensions_mut();
             let timings = if self.tracked_inactivity {
                 extensions.remove::<Timings>()
             } else {
                 None
             };
-            (extensions.remove::<OtelData>(), timings)
+            (extensions.remove::<OtelDataLock>(), timings)
         };
 
-        if let Some(OtelData { state, end_time }) = otel_data {
+        if let Some(otel_data_lock) = otel_data_lock {
+            // If we cannot lock this, someone else is still doing some operations on this span.
+            // Wait until they're finished.
+            drop(otel_data_lock.lock());
+            debug_assert!(
+                Arc::strong_count(&otel_data_lock.inner) == 1,
+                "OtelDataLock should not be held by anything else when closing spans. This is a bug in `tracing-opentelemetry`, please file a bug report. This will be ignored when compiled with --release."
+            );
+            // We don't use Weak anywhere but this is a sanity check that no one else can ever get a
+            // hold on the `Arc` again. If we checked just the strong count and someone still had a
+            // `Weak`, they could upgrade at any time.
+            debug_assert!(
+                Arc::weak_count(&otel_data_lock.inner) == 0,
+                "OtelDataLock should never be made into `Weak`. This is a bug in `tracing-opentelemetry`, please file a bug report. This will be ignored when compiled with --release."
+            );
+
+            let otel_data = Arc::try_unwrap(otel_data_lock.inner)
+                .map(|lock| lock.into_inner().unwrap())
+                .unwrap_or_else(|otel_data| otel_data.lock().unwrap().clone());
+
             // Append busy/idle timings when enabled.
             let timings = timings.map(|timings| {
                 let busy_ns = Key::new("busy_ns");
@@ -1471,19 +1519,21 @@ where
                 ]
             });
 
-            match state {
+            match otel_data.state {
                 OtelDataState::Builder {
                     builder,
                     parent_cx,
                     status,
                 } => {
-                    // Don't create the context here just to get a SpanRef since it's costly
+                    // We're not holding the extensions lock here so it's fine to just call to
+                    // opentelemetry and let it log whatever it wants. If we had a lock, we'd have
+                    // to set the default `Dispatch` to none to prevent deadlocks.
                     let mut span = builder.start_with_context(&self.tracer, &parent_cx);
                     if let Some(timings) = timings {
                         span.set_attributes(timings)
                     };
-                    span.set_status(status);
-                    if let Some(end_time) = end_time {
+                    span.set_status(status.clone());
+                    if let Some(end_time) = otel_data.end_time {
                         span.end_with_timestamp(end_time);
                     } else {
                         span.end();
@@ -1494,7 +1544,8 @@ where
                     if let Some(timings) = timings {
                         span.set_attributes(timings)
                     };
-                    end_time
+                    otel_data
+                        .end_time
                         .map_or_else(|| span.end(), |end_time| span.end_with_timestamp(end_time));
                 }
             }
@@ -1872,6 +1923,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(__reentrant_tracing_test))] // The counts would be wrong
     fn event_filter_count() {
         let mut tracer = TestTracer::default();
         let subscriber = tracing_subscriber::registry().with(
@@ -2353,7 +2405,7 @@ mod tests {
             let _enter_child = child.enter();
             assert_eq!(OtelContext::current().get(), Some(&ValueA("outer")));
             assert_eq!(OtelContext::current().get(), Some(&ValueB("inner")));
-            // Create an OpenTelemetry span using the OpentTelemetry notion of current
+            // Create an OpenTelemetry span using the OpenTelemetry notion of current
             // span to see check that it is a child of the tokio child span
             let span = tracer
                 .tracer

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -1,5 +1,5 @@
 use crate::stack::IdValueStack;
-use crate::{OtelData, OtelDataState};
+use crate::{OtelData, OtelDataLock, OtelDataState};
 pub use filtered::FilteredOpenTelemetryLayer;
 use opentelemetry::ContextGuard;
 use opentelemetry::{
@@ -7,6 +7,8 @@ use opentelemetry::{
     Context as OtelContext, Key, KeyValue, StringValue, Value,
 };
 use std::cell::RefCell;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::sync::Arc;
 use std::thread;
 #[cfg(not(all(target_arch = "wasm32", not(target_os = "wasi"))))]
 use std::time::Instant;
@@ -19,7 +21,7 @@ use tracing_core::{field, Event, Subscriber};
 use tracing_log::NormalizeEvent;
 use tracing_subscriber::layer::Context;
 use tracing_subscriber::layer::Filter;
-use tracing_subscriber::registry::{ExtensionsMut, LookupSpan};
+use tracing_subscriber::registry::LookupSpan;
 use tracing_subscriber::Layer;
 #[cfg(all(target_arch = "wasm32", not(target_os = "wasi")))]
 use web_time::Instant;
@@ -35,6 +37,10 @@ const SPAN_EVENT_COUNT_FIELD: &str = "otel.tracing_event_count";
 const EVENT_EXCEPTION_NAME: &str = "exception";
 const FIELD_EXCEPTION_MESSAGE: &str = "exception.message";
 const FIELD_EXCEPTION_STACKTRACE: &str = "exception.stacktrace";
+
+std::thread_local! {
+    static INSIDE_TRACING: AtomicBool = const { AtomicBool::new(false) }
+}
 
 /// An [OpenTelemetry] propagation layer for use in a project that uses
 /// [tracing].
@@ -125,7 +131,7 @@ pub(crate) struct WithContext {
     ///
     #[allow(clippy::type_complexity)]
     pub(crate) with_activated_otel_context:
-        fn(&tracing::Dispatch, &mut ExtensionsMut<'_>, f: &mut dyn FnMut(&OtelContext)),
+        fn(&tracing::Dispatch, &span::Id, f: &mut dyn FnMut(&OtelContext)),
 }
 
 impl WithContext {
@@ -164,10 +170,10 @@ impl WithContext {
     pub(crate) fn with_activated_otel_context(
         &self,
         dispatch: &tracing::Dispatch,
-        extensions: &mut ExtensionsMut<'_>,
+        id: &span::Id,
         mut f: impl FnMut(&OtelContext),
     ) {
-        (self.with_activated_otel_context)(dispatch, extensions, &mut f)
+        (self.with_activated_otel_context)(dispatch, id, &mut f)
     }
 }
 
@@ -919,11 +925,11 @@ where
             //
             // In these case, we prefer to emit a smaller span tree instead of panicking.
             if let Some(span) = ctx.span(parent) {
-                let mut extensions = span.extensions_mut();
-                if let Some(otel_data) = extensions.get_mut::<OtelData>() {
+                let extensions = span.extensions();
+                if let Some(otel_data) = extensions.get::<OtelDataLock>() {
                     // If the parent span has a span builder the parent span should be started
                     // so we get a proper context with the parent span.
-                    return self.with_started_cx(otel_data, &|cx| cx.clone());
+                    return self.with_started_cx(&mut otel_data.lock(), &|cx| cx.clone());
                 }
             }
         }
@@ -938,10 +944,10 @@ where
                 // we should use the current tracing context
                 ctx.lookup_current()
                     .and_then(|span| {
-                        let mut extensions = span.extensions_mut();
+                        let extensions = span.extensions();
                         extensions
-                            .get_mut::<OtelData>()
-                            .map(|data| self.with_started_cx(data, &|cx| cx.clone()))
+                            .get::<OtelDataLock>()
+                            .map(|data| self.with_started_cx(&mut data.lock(), &|cx| cx.clone()))
                     })
                     .unwrap_or_else(OtelContext::current)
             }
@@ -970,9 +976,9 @@ where
             .span(id)
             .expect("registry should have a span for the current ID");
 
-        let mut extensions = span.extensions_mut();
-        if let Some(otel_data) = extensions.get_mut::<OtelData>() {
-            f(otel_data);
+        let otel_data = span.extensions().get::<OtelDataLock>().cloned();
+        if let Some(otel_data) = otel_data {
+            f(&mut otel_data.lock());
         }
     }
 
@@ -993,19 +999,29 @@ where
         id: &span::Id,
         f: &mut dyn FnMut(&mut OtelData),
     ) {
+        let layer = dispatch
+            .downcast_ref::<OpenTelemetryLayer<S, T>>()
+            .expect("layer should downcast to expected type; this is a bug!");
+
         let subscriber = dispatch
             .downcast_ref::<S>()
             .expect("subscriber should downcast to expected type; this is a bug!");
+
         let span = subscriber
             .span(id)
             .expect("registry should have a span for the current ID");
 
-        let mut extensions = span.extensions_mut();
+        let otel_data = span.extensions().get::<OtelDataLock>().cloned();
 
-        Self::get_activated_context_extensions(dispatch, &mut extensions, f)
+        if let Some(otel_data) = otel_data {
+            let mut otel_data = otel_data.lock();
+            // Activate the context
+            layer.start_cx(&mut otel_data);
+            f(&mut otel_data);
+        }
     }
 
-    /// Retrieves the activated OpenTelemetry context from a span's extensions and passes it
+    /// Retrieves the activated OpenTelemetry context from a span's ID and passes it
     /// to the provided function.
     ///
     /// This method activates the context and extracts the current OTel `Context` from the
@@ -1015,38 +1031,18 @@ where
     /// # Parameters
     ///
     /// * `dispatch` - The tracing dispatch to downcast to the `OpenTelemetryLayer`
-    /// * `extensions` - Mutable reference to the span's extensions containing `OtelData`
+    /// * `id` - The span ID to look up in the registry
     /// * `f` - The closure to invoke with a reference to the OTel `Context`
     fn get_activated_otel_context(
         dispatch: &tracing::Dispatch,
-        extensions: &mut ExtensionsMut<'_>,
+        span: &span::Id,
         f: &mut dyn FnMut(&OtelContext),
     ) {
-        Self::get_activated_context_extensions(
-            dispatch,
-            extensions,
-            &mut |otel_data: &mut OtelData| {
-                if let OtelDataState::Context { current_cx } = &otel_data.state {
-                    f(current_cx)
-                }
-            },
-        );
-    }
-
-    fn get_activated_context_extensions(
-        dispatch: &tracing::Dispatch,
-        extensions: &mut ExtensionsMut<'_>,
-        f: &mut dyn FnMut(&mut OtelData),
-    ) {
-        let layer = dispatch
-            .downcast_ref::<OpenTelemetryLayer<S, T>>()
-            .expect("layer should downcast to expected type; this is a bug!");
-
-        if let Some(otel_data) = extensions.get_mut::<OtelData>() {
-            // Activate the context
-            layer.start_cx(otel_data);
-            f(otel_data);
-        }
+        Self::get_activated_context(dispatch, span, &mut |otel_data: &mut OtelData| {
+            if let OtelDataState::Context { current_cx } = &otel_data.state {
+                f(current_cx)
+            }
+        });
     }
 
     fn extra_span_attrs(&self) -> usize {
@@ -1079,9 +1075,18 @@ where
             status,
         } = take(&mut otel_data.state)
         {
+            // We purposefully disable all tracing inside this call. Whoever called this is most
+            // likely holding `ExtensionsMut` so if anything inside any of the opentelemetry
+            // functions tries to log anything and any layer (including this one) tries to get the
+            // extensions again, we get a deadlock.
+            INSIDE_TRACING.with(|inside| inside.store(true, Ordering::Relaxed));
+            #[cfg(all(test, reentrant_tracing_test))]
+            tracing::info!("This should not deadlock...");
             let mut span = builder.start_with_context(&self.tracer, &parent_cx);
             span.set_status(status);
             let current_cx = parent_cx.with_span(span);
+            INSIDE_TRACING.with(|inside| inside.store(false, Ordering::Relaxed));
+
             otel_data.state = OtelDataState::Context { current_cx };
         }
     }
@@ -1184,14 +1189,14 @@ where
 
         let mut status = Status::Unset;
         updates.update(&mut builder, &mut status);
-        extensions.insert(OtelData {
+        extensions.insert(OtelDataLock::new(OtelData {
             state: OtelDataState::Builder {
                 builder,
                 parent_cx,
                 status,
             },
             end_time: None,
-        });
+        }));
     }
 
     fn on_enter(&self, id: &span::Id, ctx: Context<'_, S>) {
@@ -1200,11 +1205,13 @@ where
         }
 
         let span = ctx.span(id).expect("Span not found, this is a bug");
-        let mut extensions = span.extensions_mut();
 
         if self.context_activation {
-            if let Some(otel_data) = extensions.get_mut::<OtelData>() {
-                self.with_started_cx(otel_data, &|cx| {
+            // We must not hold the extensions when starting the context to avoid potential
+            // deadlocks.
+            let otel_data = span.extensions().get::<OtelDataLock>().cloned();
+            if let Some(otel_data) = otel_data {
+                self.with_started_cx(&mut otel_data.lock(), &|cx| {
                     let guard = cx.clone().attach();
                     GUARD_STACK.with(|stack| stack.borrow_mut().push(id.clone(), guard));
                 });
@@ -1214,6 +1221,8 @@ where
                 return;
             }
         }
+
+        let mut extensions = span.extensions_mut();
 
         if let Some(timings) = extensions.get_mut::<Timings>() {
             if timings.entered_count == 0 {
@@ -1229,8 +1238,11 @@ where
         let span = ctx.span(id).expect("Span not found, this is a bug");
         let mut extensions = span.extensions_mut();
 
-        if let Some(otel_data) = extensions.get_mut::<OtelData>() {
-            otel_data.end_time = Some(crate::time::now());
+        // We don't need mutable access to this but we're taking mutable extensions for timings
+        // anyway so let's use it instead of locking it twice. This is ok because here we will not
+        // start the opentelemetry context nor will we call any other code that might use tracing.
+        if let Some(otel_data) = extensions.get_mut::<OtelDataLock>() {
+            otel_data.lock().end_time = Some(crate::time::now());
             if self.context_activation {
                 GUARD_STACK.with(|stack| stack.borrow_mut().pop(id));
             }
@@ -1260,9 +1272,9 @@ where
             span_builder_updates: &mut updates,
             sem_conv_config: self.sem_conv_config,
         });
-        let mut extensions = span.extensions_mut();
-        if let Some(otel_data) = extensions.get_mut::<OtelData>() {
-            match &mut otel_data.state {
+        let extensions = span.extensions();
+        if let Some(otel_data) = extensions.get::<OtelDataLock>() {
+            match &mut otel_data.lock().state {
                 OtelDataState::Builder {
                     builder, status, ..
                 } => {
@@ -1279,8 +1291,8 @@ where
 
     fn on_follows_from(&self, id: &Id, follows: &Id, ctx: Context<S>) {
         let span = ctx.span(id).expect("Span not found, this is a bug");
-        let mut extensions = span.extensions_mut();
-        let Some(data) = extensions.get_mut::<OtelData>() else {
+        let otel_data = span.extensions().get::<OtelDataLock>().cloned();
+        let Some(data) = otel_data else {
             return; // The span must already have been closed by us
         };
 
@@ -1288,13 +1300,22 @@ where
         // in which case we just drop the data, as opposed to panicking. This
         // uses the same reasoning as `parent_context` above.
         if let Some(follows_span) = ctx.span(follows) {
-            let mut follows_extensions = follows_span.extensions_mut();
-            let Some(follows_data) = follows_extensions.get_mut::<OtelData>() else {
+            let follows_extensions = follows_span.extensions();
+            let follows_otel_data = follows_extensions.get::<OtelDataLock>();
+            let Some(follows_data) = follows_otel_data else {
                 return; // The span must already have been closed by us
             };
+
+            let follows_data = follows_data.clone();
+            let mut follows_locked = follows_data.lock();
+            // We drop the extensions lock only after locking the inside. This is because we want to
+            // hinder potential `close` on the follows span. If we hold one or the other lock, the
+            // close implementation cannot progress to remove the span.
+            drop(follows_extensions);
+
             let follows_context =
-                self.with_started_cx(follows_data, &|cx| cx.span().span_context().clone());
-            match &mut data.state {
+                self.with_started_cx(&mut follows_locked, &|cx| cx.span().span_context().clone());
+            match &mut data.lock().state {
                 OtelDataState::Builder { builder, .. } => {
                     if let Some(ref mut links) = builder.links {
                         links.push(otel::Link::with_context(follows_context));
@@ -1318,6 +1339,10 @@ where
     /// [`ERROR`]: tracing::Level::ERROR
     /// [`Error`]: opentelemetry::trace::StatusCode::Error
     fn on_event(&self, event: &Event<'_>, ctx: Context<'_, S>) {
+        if INSIDE_TRACING.with(|inside| inside.load(Ordering::Relaxed)) {
+            // Ignore reentrant calls.
+            return;
+        }
         // Ignore events that are not in the context of a span
         if let Some(span) = event.parent().and_then(|id| ctx.span(id)).or_else(|| {
             event
@@ -1375,9 +1400,9 @@ where
                 otel_event.name = std::borrow::Cow::Borrowed(event.metadata().name());
             }
 
-            let mut extensions = span.extensions_mut();
+            let otel_data = span.extensions().get::<OtelDataLock>().cloned();
 
-            if let Some(otel_data) = extensions.get_mut::<OtelData>() {
+            if let Some(otel_data) = otel_data {
                 if self.location {
                     #[cfg(not(feature = "tracing-log"))]
                     let normalized_meta: Option<tracing_core::Metadata<'_>> = None;
@@ -1409,7 +1434,7 @@ where
                     }
                 }
 
-                match &mut otel_data.state {
+                match &mut otel_data.lock().state {
                     OtelDataState::Builder {
                         builder, status, ..
                     } => {
@@ -1449,17 +1474,36 @@ where
     fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
         let span = ctx.span(&id).expect("Span not found, this is a bug");
         // Now get mutable extensions for removal
-        let (otel_data, timings) = {
+        let (otel_data_lock, timings) = {
             let mut extensions = span.extensions_mut();
             let timings = if self.tracked_inactivity {
                 extensions.remove::<Timings>()
             } else {
                 None
             };
-            (extensions.remove::<OtelData>(), timings)
+            (extensions.remove::<OtelDataLock>(), timings)
         };
 
-        if let Some(OtelData { state, end_time }) = otel_data {
+        if let Some(otel_data_lock) = otel_data_lock {
+            // If we cannot lock this, someone else is still doing some operations on this span.
+            // Wait until they're finished.
+            drop(otel_data_lock.lock());
+            debug_assert!(
+                Arc::strong_count(&otel_data_lock.inner) == 1,
+                "OtelDataLock should not be held by anything else when closing spans. This is a bug in `tracing-opentelemetry`, please file a bug report. This will be ignored when compiled with --release."
+            );
+            // We don't use Weak anywhere but this is a sanity check that no one else can ever get a
+            // hold on the `Arc` again. If we checked just the strong count and someone still had a
+            // `Weak`, they could upgrade at any time.
+            debug_assert!(
+                Arc::weak_count(&otel_data_lock.inner) == 0,
+                "OtelDataLock should never be made into `Weak`. This is a bug in `tracing-opentelemetry`, please file a bug report. This will be ignored when compiled with --release."
+            );
+
+            let otel_data = Arc::try_unwrap(otel_data_lock.inner)
+                .map(|lock| lock.into_inner().unwrap())
+                .unwrap_or_else(|otel_data| otel_data.lock().unwrap().clone());
+
             // Append busy/idle timings when enabled.
             let timings = timings.map(|timings| {
                 let busy_ns = Key::new("busy_ns");
@@ -1471,19 +1515,21 @@ where
                 ]
             });
 
-            match state {
+            match otel_data.state {
                 OtelDataState::Builder {
                     builder,
                     parent_cx,
                     status,
                 } => {
-                    // Don't create the context here just to get a SpanRef since it's costly
+                    // We're not holding the extensions lock here so it's fine to just call to
+                    // opentelemetry and let it log whatever it wants. If we had a lock, we'd have
+                    // to set the default `Dispatch` to none to prevent deadlocks.
                     let mut span = builder.start_with_context(&self.tracer, &parent_cx);
                     if let Some(timings) = timings {
                         span.set_attributes(timings)
                     };
-                    span.set_status(status);
-                    if let Some(end_time) = end_time {
+                    span.set_status(status.clone());
+                    if let Some(end_time) = otel_data.end_time {
                         span.end_with_timestamp(end_time);
                     } else {
                         span.end();
@@ -1494,7 +1540,8 @@ where
                     if let Some(timings) = timings {
                         span.set_attributes(timings)
                     };
-                    end_time
+                    otel_data
+                        .end_time
                         .map_or_else(|| span.end(), |end_time| span.end_with_timestamp(end_time));
                 }
             }
@@ -1872,6 +1919,7 @@ mod tests {
     }
 
     #[test]
+    #[cfg(not(reentrant_tracing_test))] // The counts would be wrong
     fn event_filter_count() {
         let mut tracer = TestTracer::default();
         let subscriber = tracing_subscriber::registry().with(

--- a/src/layer/filtered.rs
+++ b/src/layer/filtered.rs
@@ -8,7 +8,7 @@ use tracing_subscriber::{
     Layer,
 };
 
-use crate::{OtelData, OtelDataState};
+use crate::{OtelDataLock, OtelDataState};
 
 use super::{OpenTelemetryLayer, SPAN_EVENT_COUNT_FIELD};
 
@@ -132,15 +132,19 @@ where
 
     fn on_close(&self, id: span::Id, ctx: Context<'_, S>) {
         let span = ctx.span(&id).expect("Span not found, this is a bug");
-        let mut extensions = span.extensions_mut();
+        let otel_data = span.extensions().get::<OtelDataLock>().cloned();
 
-        let count = extensions.remove::<EventCount>().map_or(0, |count| count.0);
-        if let Some(OtelData { state, end_time: _ }) = extensions.get_mut::<OtelData>() {
+        let count = span
+            .extensions_mut()
+            .remove::<EventCount>()
+            .map_or(0, |count| count.0);
+
+        if let Some(otel_data) = otel_data {
             let key_value = KeyValue::new(
                 Key::from_static_str(SPAN_EVENT_COUNT_FIELD),
                 Value::I64(i64::from(count)),
             );
-            match state {
+            match &mut otel_data.lock().state {
                 OtelDataState::Builder {
                     builder,
                     parent_cx: _,
@@ -155,7 +159,6 @@ where
             }
         }
 
-        drop(extensions);
         drop(span);
 
         self.inner.on_close(id, ctx);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -122,61 +122,46 @@ mod span_ext;
 
 mod stack;
 
-use std::time::SystemTime;
+use std::{
+    sync::{Arc, Mutex, MutexGuard},
+    time::SystemTime,
+};
 
 pub use layer::{layer, FilteredOpenTelemetryLayer, OpenTelemetryLayer};
 
 #[cfg(feature = "metrics")]
 pub use metrics::MetricsLayer;
-use opentelemetry::trace::TraceContextExt as _;
 pub use otel_context::get_otel_context;
 pub use span_ext::{OpenTelemetrySpanExt, SetParentError};
 
+#[derive(Debug, Clone)]
+struct OtelDataLock {
+    inner: Arc<Mutex<OtelData>>,
+}
+
+impl OtelDataLock {
+    fn lock(&self) -> MutexGuard<'_, OtelData> {
+        self.inner.lock().expect("otel data lock poisoned")
+    }
+
+    fn new(inner: OtelData) -> Self {
+        Self {
+            inner: Arc::new(Mutex::new(inner)),
+        }
+    }
+}
+
 /// Per-span OpenTelemetry data tracked by this crate.
-#[derive(Debug)]
-pub struct OtelData {
+#[derive(Debug, Clone)]
+struct OtelData {
     /// The state of the OtelData, which can either be a builder or a context.
     state: OtelDataState,
     /// The end time of the span if it has been exited.
     end_time: Option<SystemTime>,
 }
 
-impl OtelData {
-    /// Gets the trace ID of the span.
-    ///
-    /// Returns `None` if the context has not been built yet. This can be forced e.g. by calling
-    /// [`context`] on the span (not on `OtelData`) or if [context activation] was not explicitly
-    /// opted-out of, simply entering the span for the first time.
-    ///
-    /// [`context`]: OpenTelemetrySpanExt::context
-    /// [context activation]: OpenTelemetryLayer::with_context_activation
-    pub fn trace_id(&self) -> Option<opentelemetry::TraceId> {
-        if let OtelDataState::Context { current_cx } = &self.state {
-            Some(current_cx.span().span_context().trace_id())
-        } else {
-            None
-        }
-    }
-
-    /// Gets the span ID of the span.
-    ///
-    /// Returns `None` if the context has not been built yet. This can be forced e.g. by calling
-    /// [`context`] on the span (not on `OtelData`) or if [context activation] was not explicitly
-    /// opted-out of, simply entering the span for the first time.
-    ///
-    /// [`context`]: OpenTelemetrySpanExt::context
-    /// [context activation]: OpenTelemetryLayer::with_context_activation
-    pub fn span_id(&self) -> Option<opentelemetry::SpanId> {
-        if let OtelDataState::Context { current_cx } = &self.state {
-            Some(current_cx.span().span_context().span_id())
-        } else {
-            None
-        }
-    }
-}
-
 /// The state of the OpenTelemetry data for a span.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 #[allow(clippy::large_enum_variant)]
 pub(crate) enum OtelDataState {
     /// The span is being built, with a parent context and a builder.

--- a/src/otel_context.rs
+++ b/src/otel_context.rs
@@ -1,15 +1,16 @@
 use crate::layer::WithContext;
-use tracing::Dispatch;
-use tracing_subscriber::registry::ExtensionsMut;
+use tracing::{span, Dispatch};
 
-/// Utility functions to allow tracing [`ExtensionsMut`]s to return
-/// [OpenTelemetry] [`Context`]s.
+/// Utility functions to allow [`tracing::span::Id`]s to return [OpenTelemetry] [`Context`]s. Note
+/// that this will internally try to lock [`Extensions`] so the caller must not be holding
+/// [`ExtensionsMut`] when calling this, otherwise the method may deadlock.
 ///
+/// [`Extensions`]: tracing_subscriber::registry::Extensions
 /// [`ExtensionsMut`]: tracing_subscriber::registry::ExtensionsMut
 /// [OpenTelemetry]: https://opentelemetry.io
 /// [`Context`]: opentelemetry::Context
 ///
-/// Extracts the OpenTelemetry [`Context`] associated with this span extensions.
+/// Extracts the OpenTelemetry [`Context`] associated with this span.
 ///
 /// This method retrieves the OpenTelemetry context data that has been stored
 /// for the span by the OpenTelemetry layer. The context includes the span's
@@ -33,7 +34,8 @@ use tracing_subscriber::registry::ExtensionsMut;
 ///     D: LookupSpan<'a>,
 /// {
 ///     if let Some(dispatch) = weak_dispatch.upgrade() {
-///         if let Some(otel_context) = get_otel_context(&mut span_ref.extensions_mut(), &dispatch) {
+///         // Be sure *NOT* to hold `ExtensionsMut` when calling this.
+///         if let Some(otel_context) = get_otel_context(&span_ref.id(), &dispatch) {
 ///             // Process the extracted context
 ///             let span = otel_context.span();
 ///             let span_context = span.span_context();
@@ -49,16 +51,13 @@ use tracing_subscriber::registry::ExtensionsMut;
 ///
 /// - When working with multiple subscriber configurations
 /// - When implementing advanced tracing middleware that manages multiple dispatches
-pub fn get_otel_context(
-    extensions: &mut ExtensionsMut<'_>,
-    dispatch: &Dispatch,
-) -> Option<opentelemetry::Context> {
+pub fn get_otel_context(span_id: &span::Id, dispatch: &Dispatch) -> Option<opentelemetry::Context> {
     let mut cx = None;
     if let Some(get_context) = dispatch.downcast_ref::<WithContext>() {
         // If our span hasn't been built, we should build it and get the context in one call
         get_context.with_activated_otel_context(
             dispatch,
-            extensions,
+            span_id,
             |current_cx: &opentelemetry::Context| {
                 cx = Some(current_cx.clone());
             },

--- a/src/otel_context.rs
+++ b/src/otel_context.rs
@@ -1,15 +1,16 @@
 use crate::layer::WithContext;
-use tracing::Dispatch;
-use tracing_subscriber::registry::ExtensionsMut;
+use tracing::{span, Dispatch};
 
-/// Utility functions to allow tracing [`ExtensionsMut`]s to return
-/// [OpenTelemetry] [`Context`]s.
+/// Utility functions to allow [`tracing::span::Id`]s to return [OpenTelemetry] [`Context`]s. Note
+/// that this will internally try to lock [`Extensions`] so the caller must not be holding
+/// [`ExtensionsMut`] when calling this, otherwise the method may deadlock.
 ///
+/// [`Extensions`]: tracing_subscriber::registry::Extensions
 /// [`ExtensionsMut`]: tracing_subscriber::registry::ExtensionsMut
 /// [OpenTelemetry]: https://opentelemetry.io
 /// [`Context`]: opentelemetry::Context
 ///
-/// Extracts the OpenTelemetry [`Context`] associated with this span extensions.
+/// Extracts the OpenTelemetry [`Context`] associated with this span.
 ///
 /// This method retrieves the OpenTelemetry context data that has been stored
 /// for the span by the OpenTelemetry layer. The context includes the span's
@@ -33,7 +34,8 @@ use tracing_subscriber::registry::ExtensionsMut;
 ///     D: LookupSpan<'a>,
 /// {
 ///     if let Some(dispatch) = weak_dispatch.upgrade() {
-///         if let Some(otel_context) = get_otel_context(&mut span_ref.extensions_mut(), &dispatch) {
+///            // Be sure *NOT* to hold `ExtensionsMut` when calling this.
+///         if let Some(otel_context) = get_otel_context(&mut span_ref.id(), &dispatch) {
 ///             // Process the extracted context
 ///             let span = otel_context.span();
 ///             let span_context = span.span_context();
@@ -49,16 +51,13 @@ use tracing_subscriber::registry::ExtensionsMut;
 ///
 /// - When working with multiple subscriber configurations
 /// - When implementing advanced tracing middleware that manages multiple dispatches
-pub fn get_otel_context(
-    extensions: &mut ExtensionsMut<'_>,
-    dispatch: &Dispatch,
-) -> Option<opentelemetry::Context> {
+pub fn get_otel_context(span_id: &span::Id, dispatch: &Dispatch) -> Option<opentelemetry::Context> {
     let mut cx = None;
     if let Some(get_context) = dispatch.downcast_ref::<WithContext>() {
         // If our span hasn't been built, we should build it and get the context in one call
         get_context.with_activated_otel_context(
             dispatch,
-            extensions,
+            span_id,
             |current_cx: &opentelemetry::Context| {
                 cx = Some(current_cx.clone());
             },

--- a/tests/otel_context.rs
+++ b/tests/otel_context.rs
@@ -49,18 +49,14 @@ where
         let _ = self.dispatch.set(subscriber.downgrade());
     }
 
-    fn on_enter(&self, id: &tracing::span::Id, ctx: Context<'_, S>) {
+    fn on_enter(&self, id: &tracing::span::Id, _ctx: Context<'_, S>) {
         if let Some(weak_dispatch) = self.dispatch.get() {
-            // Get the span reference from the registry when the span is entered
-            if let Some(span_ref) = ctx.span(id) {
-                // Use OpenTelemetryContext to extract the OpenTelemetry context
-                let mut extensions = span_ref.extensions_mut();
-                if let Some(dispatch) = weak_dispatch.upgrade() {
-                    if let Some(otel_context) = get_otel_context(&mut extensions, &dispatch) {
-                        // Store the extracted context for verification
-                        if let Ok(mut contexts) = self.extracted_contexts.lock() {
-                            contexts.push(otel_context);
-                        }
+            // Use OpenTelemetryContext to extract the OpenTelemetry context
+            if let Some(dispatch) = weak_dispatch.upgrade() {
+                if let Some(otel_context) = get_otel_context(id, &dispatch) {
+                    // Store the extracted context for verification
+                    if let Ok(mut contexts) = self.extracted_contexts.lock() {
+                        contexts.push(otel_context);
                     }
                 }
             }


### PR DESCRIPTION
## Motivation

There is a potential deadlock described in #250 where we lock `ExtensionsMut` when entering a span, we let `opentelemetry` activate the context, it tries to log through `tracing` in that operation which in turn calls `on_event` in this layer and we try to lock `ExtensionsMut` again.

## Solution

Instead of accessing span's internal state through `ExtensionsMut`, we store an `Arc<Mutex<OtelData>>`, clone the `Arc` and then lock it to access it. This allows us to hold onto the state without deadlocking when other layers try to lock the extensions in re-entrant calls.

There's a test to check for this but it needs to be run with `RUSTFLAGS='--cfg reentrant_tracing_test'` environment. I did not put that into the CI because changing the environment forces recompilation of every dependency. So I'm still looking whether I'm able to do this a bit better or if I'll just drop the test.