### PR TITLE
Mimimize package size

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,6 +14,7 @@ keywords = ["tracing", "opentelemetry", "jaeger", "zipkin", "async"]
 license = "MIT"
 edition = "2021"
 rust-version = "1.75.0"
+include = ["src/**/*.rs", "tests/**/*.rs", "CHANGELOG.md", "README.md", "Cargo.toml", "LICENSE"]
 
 [features]
 default = ["tracing-log", "metrics"]

--- a/README.md
+++ b/README.md
@@ -76,7 +76,7 @@ $ cargo run --example opentelemetry-otlp
 $ firefox http://localhost:16686/
 ```
 
-![Jaeger UI](trace.png)
+![Jaeger UI](https://raw.githubusercontent.com/tokio-rs/tracing-opentelemetry/refs/heads/v0.1.x/trace.png)
 
 ## Feature Flags
 


### PR DESCRIPTION
## Motivation
During a dependency review we noticed that tracing-opentelemetry includes a binary file (picture) in the source code uploaded to crates.io. While this is on it's own not a problem, its still wasteful as it copies this picture to each system using tracing-opentelemetry as dependency. Additionally it includes binary and therefore harder to review data in the published code. This PR changes the link in the readme to rely on a copy of the image hosted by github instead. 


## Solution

This PR sets a `include` configuration to explicitly list which files should be part of the published package.

This reduces the package size from 41 files, 431.4KiB (153.4KiB compressed) to 24 files, 298.3KiB (61.4KiB compressed), which directly translates to 500GB less traffic per month for crates.io