### PR TITLE
Add support for otel.unit field in MetricsLayer

### DIFF
--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -22,6 +22,7 @@ const METRIC_PREFIX_MONOTONIC_COUNTER: &str = "monotonic_counter.";
 const METRIC_PREFIX_COUNTER: &str = "counter.";
 const METRIC_PREFIX_HISTOGRAM: &str = "histogram.";
 const METRIC_PREFIX_GAUGE: &str = "gauge.";
+const METRIC_UNIT_FIELD: &str = "otel.unit";
 
 const I64_MAX: u64 = i64::MAX as u64;
 
@@ -59,6 +60,7 @@ impl Instruments {
         meter: &Meter,
         instrument_type: InstrumentType,
         metric_name: &'static str,
+        unit: Option<&str>,
         attributes: &[KeyValue],
     ) {
         fn update_or_insert<T>(
@@ -89,7 +91,13 @@ impl Instruments {
                 update_or_insert(
                     &self.u64_counter,
                     metric_name,
-                    || meter.u64_counter(metric_name).build(),
+                    || {
+                        let mut b = meter.u64_counter(metric_name);
+                        if let Some(u) = unit {
+                            b = b.with_unit(u.to_owned());
+                        }
+                        b.build()
+                    },
                     |ctr| ctr.add(value, attributes),
                 );
             }
@@ -97,7 +105,13 @@ impl Instruments {
                 update_or_insert(
                     &self.f64_counter,
                     metric_name,
-                    || meter.f64_counter(metric_name).build(),
+                    || {
+                        let mut b = meter.f64_counter(metric_name);
+                        if let Some(u) = unit {
+                            b = b.with_unit(u.to_owned());
+                        }
+                        b.build()
+                    },
                     |ctr| ctr.add(value, attributes),
                 );
             }
@@ -105,7 +119,13 @@ impl Instruments {
                 update_or_insert(
                     &self.i64_up_down_counter,
                     metric_name,
-                    || meter.i64_up_down_counter(metric_name).build(),
+                    || {
+                        let mut b = meter.i64_up_down_counter(metric_name);
+                        if let Some(u) = unit {
+                            b = b.with_unit(u.to_owned());
+                        }
+                        b.build()
+                    },
                     |ctr| ctr.add(value, attributes),
                 );
             }
@@ -113,7 +133,13 @@ impl Instruments {
                 update_or_insert(
                     &self.f64_up_down_counter,
                     metric_name,
-                    || meter.f64_up_down_counter(metric_name).build(),
+                    || {
+                        let mut b = meter.f64_up_down_counter(metric_name);
+                        if let Some(u) = unit {
+                            b = b.with_unit(u.to_owned());
+                        }
+                        b.build()
+                    },
                     |ctr| ctr.add(value, attributes),
                 );
             }
@@ -121,7 +147,13 @@ impl Instruments {
                 update_or_insert(
                     &self.u64_histogram,
                     metric_name,
-                    || meter.u64_histogram(metric_name).build(),
+                    || {
+                        let mut b = meter.u64_histogram(metric_name);
+                        if let Some(u) = unit {
+                            b = b.with_unit(u.to_owned());
+                        }
+                        b.build()
+                    },
                     |rec| rec.record(value, attributes),
                 );
             }
@@ -129,7 +161,13 @@ impl Instruments {
                 update_or_insert(
                     &self.f64_histogram,
                     metric_name,
-                    || meter.f64_histogram(metric_name).build(),
+                    || {
+                        let mut b = meter.f64_histogram(metric_name);
+                        if let Some(u) = unit {
+                            b = b.with_unit(u.to_owned());
+                        }
+                        b.build()
+                    },
                     |rec| rec.record(value, attributes),
                 );
             }
@@ -137,7 +175,13 @@ impl Instruments {
                 update_or_insert(
                     &self.u64_gauge,
                     metric_name,
-                    || meter.u64_gauge(metric_name).build(),
+                    || {
+                        let mut b = meter.u64_gauge(metric_name);
+                        if let Some(u) = unit {
+                            b = b.with_unit(u.to_owned());
+                        }
+                        b.build()
+                    },
                     |rec| rec.record(value, attributes),
                 );
             }
@@ -145,7 +189,13 @@ impl Instruments {
                 update_or_insert(
                     &self.i64_gauge,
                     metric_name,
-                    || meter.i64_gauge(metric_name).build(),
+                    || {
+                        let mut b = meter.i64_gauge(metric_name);
+                        if let Some(u) = unit {
+                            b = b.with_unit(u.to_owned());
+                        }
+                        b.build()
+                    },
                     |rec| rec.record(value, attributes),
                 );
             }
@@ -153,7 +203,13 @@ impl Instruments {
                 update_or_insert(
                     &self.f64_gauge,
                     metric_name,
-                    || meter.f64_gauge(metric_name).build(),
+                    || {
+                        let mut b = meter.f64_gauge(metric_name);
+                        if let Some(u) = unit {
+                            b = b.with_unit(u.to_owned());
+                        }
+                        b.build()
+                    },
                     |rec| rec.record(value, attributes),
                 );
             }
@@ -164,6 +220,7 @@ impl Instruments {
 pub(crate) struct MetricVisitor<'a> {
     attributes: &'a mut SmallVec<[KeyValue; 8]>,
     visited_metrics: &'a mut SmallVec<[(&'static str, InstrumentType); 2]>,
+    unit: &'a mut Option<String>,
 }
 
 impl Visit for MetricVisitor<'_> {
@@ -240,6 +297,10 @@ impl Visit for MetricVisitor<'_> {
     }
 
     fn record_str(&mut self, field: &Field, value: &str) {
+        if field.name() == METRIC_UNIT_FIELD {
+            *self.unit = Some(value.to_owned());
+            return;
+        }
         self.attributes
             .push(KeyValue::new(field.name(), value.to_owned()));
     }
@@ -357,6 +418,19 @@ impl Visit for MetricVisitor<'_> {
 /// info!(monotonic_counter.foo = 1, bar = "baz", qux = 2);
 /// ```
 ///
+/// # Units
+///
+/// A unit can be associated with a metric by adding an `otel.unit` field
+/// to the event. The unit is applied to the instrument when it is first created.
+/// Subsequent events for the same metric name that provide a different (or no)
+/// unit will have no effect on the unit.
+///
+/// ```
+/// # use tracing::info;
+/// info!(monotonic_counter.foo = 1_u64, otel.unit = "By");
+/// info!(histogram.bar = 1.4_f64, otel.unit = "ms");
+/// ```
+///
 /// # Implementation Details
 ///
 /// `MetricsLayer` holds a set of maps, with each map corresponding to a
@@ -449,13 +523,15 @@ where
     fn on_event(&self, event: &tracing::Event<'_>, _ctx: Context<'_, S>) {
         let mut attributes = SmallVec::new();
         let mut visited_metrics = SmallVec::new();
+        let mut unit: Option<String> = None;
         let mut metric_visitor = MetricVisitor {
             attributes: &mut attributes,
             visited_metrics: &mut visited_metrics,
+            unit: &mut unit,
         };
         event.record(&mut metric_visitor);
 
-        // associate attrivutes with visited metrics
+        // associate attributes with visited metrics
         visited_metrics
             .into_iter()
             .for_each(|(metric_name, value)| {
@@ -463,6 +539,7 @@ where
                     &self.meter,
                     value,
                     metric_name,
+                    unit.as_deref(),
                     attributes.as_slice(),
                 );
             })

--- a/tests/metrics_publishing.rs
+++ b/tests/metrics_publishing.rs
@@ -23,6 +23,7 @@ async fn u64_counter_is_exported() {
         InstrumentKind::Counter,
         1_u64,
         None,
+        None,
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -37,6 +38,7 @@ async fn u64_counter_is_exported_i64_at_instrumentation_point() {
         "hello_world2".to_string(),
         InstrumentKind::Counter,
         1_u64,
+        None,
         None,
     );
 
@@ -53,6 +55,7 @@ async fn f64_counter_is_exported() {
         InstrumentKind::Counter,
         1.000000123_f64,
         None,
+        None,
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -67,6 +70,7 @@ async fn i64_up_down_counter_is_exported() {
         "pebcak".to_string(),
         InstrumentKind::UpDownCounter,
         -5_i64,
+        None,
         None,
     );
 
@@ -83,6 +87,7 @@ async fn i64_up_down_counter_is_exported_u64_at_instrumentation_point() {
         InstrumentKind::UpDownCounter,
         5_i64,
         None,
+        None,
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -98,6 +103,7 @@ async fn f64_up_down_counter_is_exported() {
         InstrumentKind::UpDownCounter,
         99.123_f64,
         None,
+        None,
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -108,8 +114,13 @@ async fn f64_up_down_counter_is_exported() {
 
 #[tokio::test]
 async fn u64_gauge_is_exported() {
-    let (subscriber, exporter) =
-        init_subscriber("gygygy".to_string(), InstrumentKind::Gauge, 2_u64, None);
+    let (subscriber, exporter) = init_subscriber(
+        "gygygy".to_string(),
+        InstrumentKind::Gauge,
+        2_u64,
+        None,
+        None,
+    );
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(gauge.gygygy = 1_u64);
@@ -120,8 +131,13 @@ async fn u64_gauge_is_exported() {
 
 #[tokio::test]
 async fn f64_gauge_is_exported() {
-    let (subscriber, exporter) =
-        init_subscriber("huitt".to_string(), InstrumentKind::Gauge, 2_f64, None);
+    let (subscriber, exporter) = init_subscriber(
+        "huitt".to_string(),
+        InstrumentKind::Gauge,
+        2_f64,
+        None,
+        None,
+    );
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(gauge.huitt = 1_f64);
@@ -132,8 +148,13 @@ async fn f64_gauge_is_exported() {
 
 #[tokio::test]
 async fn i64_gauge_is_exported() {
-    let (subscriber, exporter) =
-        init_subscriber("samsagaz".to_string(), InstrumentKind::Gauge, 2_i64, None);
+    let (subscriber, exporter) = init_subscriber(
+        "samsagaz".to_string(),
+        InstrumentKind::Gauge,
+        2_i64,
+        None,
+        None,
+    );
 
     tracing::subscriber::with_default(subscriber, || {
         tracing::info!(gauge.samsagaz = 1_i64);
@@ -149,6 +170,7 @@ async fn u64_histogram_is_exported() {
         InstrumentKind::Histogram,
         9_u64,
         None,
+        None,
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -163,6 +185,7 @@ async fn f64_histogram_is_exported() {
         "abcdefg_racecar".to_string(),
         InstrumentKind::Histogram,
         777.0012_f64,
+        None,
         None,
     );
 
@@ -185,6 +208,7 @@ async fn u64_counter_with_attributes_is_exported() {
             KeyValue::new("str_key_1", "foo"),
             KeyValue::new("bool_key_1", true),
         ]),
+        None,
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -213,6 +237,7 @@ async fn f64_counter_with_attributes_is_exported() {
             KeyValue::new("str_key_1", "foo"),
             KeyValue::new("bool_key_1", true),
         ]),
+        None,
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -241,6 +266,7 @@ async fn i64_up_down_counter_with_attributes_is_exported() {
             KeyValue::new("str_key_1", "foo"),
             KeyValue::new("bool_key_1", true),
         ]),
+        None,
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -269,6 +295,7 @@ async fn f64_up_down_counter_with_attributes_is_exported() {
             KeyValue::new("str_key_1", "foo"),
             KeyValue::new("bool_key_1", true),
         ]),
+        None,
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -297,6 +324,7 @@ async fn f64_gauge_with_attributes_is_exported() {
             KeyValue::new("str_key_1", "foo"),
             KeyValue::new("bool_key_1", true),
         ]),
+        None,
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -325,6 +353,7 @@ async fn u64_gauge_with_attributes_is_exported() {
             KeyValue::new("str_key_1", "foo"),
             KeyValue::new("bool_key_1", true),
         ]),
+        None,
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -353,6 +382,7 @@ async fn i64_gauge_with_attributes_is_exported() {
             KeyValue::new("str_key_1", "foo"),
             KeyValue::new("bool_key_1", true),
         ]),
+        None,
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -381,6 +411,7 @@ async fn u64_histogram_with_attributes_is_exported() {
             KeyValue::new("str_key_1", "foo"),
             KeyValue::new("bool_key_1", true),
         ]),
+        None,
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -409,6 +440,7 @@ async fn f64_histogram_with_attributes_is_exported() {
             KeyValue::new("str_key_1", "foo"),
             KeyValue::new("bool_key_1", true),
         ]),
+        None,
     );
 
     tracing::subscriber::with_default(subscriber, || {
@@ -431,6 +463,7 @@ async fn display_attribute_is_exported() {
         InstrumentKind::Counter,
         1_u64,
         Some(vec![KeyValue::new("display_key_1", "display: foo")]),
+        None,
     );
 
     struct DisplayAttribute(String);
@@ -459,6 +492,7 @@ async fn debug_attribute_is_exported() {
         InstrumentKind::Counter,
         1_u64,
         Some(vec![KeyValue::new("debug_key_1", "debug: foo")]),
+        None,
     );
 
     struct DebugAttribute(String);
@@ -480,11 +514,77 @@ async fn debug_attribute_is_exported() {
     });
 }
 
+#[tokio::test]
+async fn unit_is_exported() {
+    let (subscriber, exporter) = init_subscriber(
+        "hello_world".to_string(),
+        InstrumentKind::Histogram,
+        1.5_f64,
+        None,
+        Some("s".to_string()),
+    );
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(histogram.hello_world = 1.5_f64, otel.unit = "s");
+        exporter.export().unwrap();
+    });
+}
+
+#[tokio::test]
+async fn default_unit_is_empty() {
+    let (subscriber, exporter) = init_subscriber(
+        "hello_world".to_string(),
+        InstrumentKind::Histogram,
+        1.5_f64,
+        None,
+        Some("".to_string()),
+    );
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(histogram.hello_world = 1.5_f64);
+        exporter.export().unwrap();
+    });
+}
+
+#[tokio::test]
+async fn first_unit_wins_when_unit_changes() {
+    let (subscriber, exporter) = init_subscriber(
+        "hello_world".to_string(),
+        InstrumentKind::Counter,
+        3_u64,
+        None,
+        Some("ms".to_string()),
+    );
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(monotonic_counter.hello_world = 1_u64, otel.unit = "ms");
+        tracing::info!(monotonic_counter.hello_world = 2_u64, otel.unit = "s");
+        exporter.export().unwrap();
+    });
+}
+
+#[tokio::test]
+async fn otel_unit_is_not_forwarded_as_attribute() {
+    let (subscriber, exporter) = init_subscriber(
+        "hello_world".to_string(),
+        InstrumentKind::Gauge,
+        1_i64,
+        Some(vec![]),
+        None,
+    );
+
+    tracing::subscriber::with_default(subscriber, || {
+        tracing::info!(gauge.hello_world = 1_i64, otel.unit = "Cel");
+        exporter.export().unwrap();
+    });
+}
+
 fn init_subscriber<T>(
     expected_metric_name: String,
     expected_instrument_kind: InstrumentKind,
     expected_value: T,
     expected_attributes: Option<Vec<KeyValue>>,
+    expected_unit: Option<String>,
 ) -> (impl Subscriber + 'static, TestExporter<T>) {
     let reader = ManualReader::builder().build();
     let reader = TestReader {
@@ -499,6 +599,7 @@ fn init_subscriber<T>(
         expected_instrument_kind,
         expected_value,
         expected_attributes,
+        expected_unit,
         reader,
     };
 
@@ -544,6 +645,7 @@ struct TestExporter<T> {
     expected_instrument_kind: InstrumentKind,
     expected_value: T,
     expected_attributes: Option<Vec<KeyValue>>,
+    expected_unit: Option<String>,
     reader: TestReader,
 }
 
@@ -594,6 +696,10 @@ where
 
             scope_metrics.metrics().for_each(|metric| {
                 assert_eq!(metric.name(), self.expected_metric_name);
+
+                if let Some(expected_unit) = &self.expected_unit {
+                    assert_eq!(metric.unit(), expected_unit.as_str());
+                }
 
                 match self.expected_instrument_kind {
                     InstrumentKind::Counter | InstrumentKind::UpDownCounter => {


### PR DESCRIPTION
<!--
Thank you for your Pull Request. Please provide a description above and review
the requirements below.

Bug fixes and new features should include tests.

Contributors guide: https://github.com/tokio-rs/tracing-opentelemetry/blob/master/CONTRIBUTING.md
-->

Closes issue #254 

## Motivation

<!--
Explain the context and why you're making that change. What is the problem
you're trying to solve? If a new feature is being added, describe the intended
use case that feature fulfills.
-->

MetricsLayer provides no way to associate a unit with a published metric. Units are a first-class concept in the [OpenTelemetry spec](https://opentelemetry.io/docs/specs/otel/metrics/api/#instrument-unit) and the SDK supports them at instrument creation time, but users of tracing-opentelemetry have no mechanism to supply one from a tracing event. This means all metrics exported via MetricsLayer are missing unit information, which reduces their usefulness in observability backends that display or aggregate by unit.

## Solution

<!--
Summarize the solution and provide any necessary context needed to understand
the code change.
-->

Added support for a special `otel.unit` field on tracing events. When present, the value is passed to the instrument builder when the instrument is first created:

```
info!(histogram.response_time = 1.4_f64, otel.unit = "ms");
info!(monotonic_counter.request_size = 1_u64, otel.unit = "By");
```