### PR TITLE
chore: Upgrade to OpenTelemetry 0.32 and fix benchmark dependency compatibility

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Upgrade from opentelemetry to 0.32.0. Refer to the upstream
+  [changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-sdk/CHANGELOG.md#0320)
+- Update tracing ecosystem dependencies to latest compatible patch versions.
+
 ## [0.32.1](https://github.com/tokio-rs/tracing-opentelemetry/compare/v0.32.0...v0.32.1) - 2025-12-17
 
 ### Added
@@ -21,7 +27,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- Remove unwanted dependency on opentelemetry sdk crate ([#241](https://github.com/tokio-rs/tracing-opentelemetry/pull/241))
+- Remove unwanted dependency on opentelemetry sdk
+  crate ([#241](https://github.com/tokio-rs/tracing-opentelemetry/pull/241))
 - update README.md links to use the latest version ([#239](https://github.com/tokio-rs/tracing-opentelemetry/pull/239))
 - remove thiserror and unused dependencies ([#238](https://github.com/tokio-rs/tracing-opentelemetry/pull/238))
 
@@ -34,10 +41,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - OpenTelemetry context activation ([#202](https://github.com/tokio-rs/tracing-opentelemetry/pull/202))
-  - Trace ID and span ID can be obtained from `OtelData` via dedicated functions. Note that these
-    will be available only if the context has already been built. (#233)
-- Correctly track entered and exited state for timings ([#212](https://github.com/tokio-rs/tracing-opentelemetry/pull/212))
-- Slightly improve error message on version mismatch ([#211](https://github.com/tokio-rs/tracing-opentelemetry/pull/211))
+    - Trace ID and span ID can be obtained from `OtelData` via dedicated functions. Note that these
+      will be available only if the context has already been built. (#233)
+- Correctly track entered and exited state for
+  timings ([#212](https://github.com/tokio-rs/tracing-opentelemetry/pull/212))
+- Slightly improve error message on version
+  mismatch ([#211](https://github.com/tokio-rs/tracing-opentelemetry/pull/211))
 - Remove Lazy for thread_local static ([#215](https://github.com/tokio-rs/tracing-opentelemetry/pull/215))
 - Update description of special fields and semantic conventions
 
@@ -54,7 +63,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   opentelemetry semantic conventions for code.  ([#209](https://github.com/tokio-rs/tracing-opentelemetry/pull/209))
 - Remove the `metrics_gauge_unstable` feature.
 
-
 # 0.31.0 (June 2, 2025)
 
 ### Breaking Changes
@@ -65,8 +73,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `OpenTelemetrySpanExt::add_event` and `OpenTelemetrySpanExt::add_event_with_timestamp` 
-  functions to allow adding OpenTelemetry events directly to a `tracing::Span`, enabling the use of dynamic attribute keys 
+- Add `OpenTelemetrySpanExt::add_event` and `OpenTelemetrySpanExt::add_event_with_timestamp`
+  functions to allow adding OpenTelemetry events directly to a `tracing::Span`, enabling the use of dynamic attribute
+  keys
   and custom event timestamps.
 
 # 0.30.0 (March 23, 2025)
@@ -223,6 +232,7 @@ This release adds optional support for recording `std::error::Error`s using
 Thanks to @lilymara-onesignal for contributing to this release!
 
 [thread-semconv]: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/exceptions/
+
 [#2135]: https://github.com/tokio-rs/tracing/pull/2135
 
 # 0.17.3 (June 7, 2022)
@@ -261,9 +271,13 @@ Thanks to new contributors @lilymara-onesignal, @hubertbudzynski, and @DevinCarr
 for contributing to this release!
 
 [thread-semconv]: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/span-general/#source-code-attributes
+
 [#2134]: https://github.com/tokio-rs/tracing/pull/2134
+
 [#2122]: https://github.com/tokio-rs/tracing/pull/2122
+
 [#2124]: https://github.com/tokio-rs/tracing/pull/2124
+
 [#2099]: https://github.com/tokio-rs/tracing/pull/2099
 
 # 0.17.2 (February 21, 2022)
@@ -276,6 +290,7 @@ This release fixes [an issue][#1944] introduced in v0.17.1 where
 - Compilation failure with `tracing-log` feature disabled ([#1949])
 
 [#1949]: https://github.com/tokio-rs/tracing/pull/1917
+
 [#1944]: https://github.com/tokio-rs/tracing/issues/1944
 
 # 0.17.1 (February 11, 2022) (YANKED)
@@ -286,6 +301,7 @@ This release fixes [an issue][#1944] introduced in v0.17.1 where
   forwarded events (defaults to on) ([#1911])
 - `OpenTelemetryLayer::with_event_location` to control whether source locations
   are recorded ([#1911])
+
 ### Changed
 
 - Avoid unnecessary allocations to improve performance when recording events
@@ -294,6 +310,7 @@ This release fixes [an issue][#1944] introduced in v0.17.1 where
 Thanks to @djc for contributing to this release!
 
 [#1917]: https://github.com/tokio-rs/tracing/pull/1917
+
 [#1911]: https://github.com/tokio-rs/tracing/pull/1911
 
 # 0.17.0 (February 3, 2022)
@@ -320,7 +337,9 @@ Thanks to @djc for contributing to this release!
 Thanks to @LehMaxence for contributing to this release!
 
 [v0.3.0 changelog]: https://github.com/tokio-rs/tracing/releases/tag/tracing-subscriber-0.3.0
+
 [#1516]: https://github.com/tokio-rs/tracing/pull/1516
+
 [#1677]: https://github.com/tokio-rs/tracing/pull/1677
 
 # 0.15.0 (August 7, 2021)
@@ -352,7 +371,9 @@ Thanks to @Drevoed, @lilymara-onesignal, and @Folyd for contributing
 to this release!
 
 [#1441]: https://github.com/tokio-rs/tracing/pull/1441
+
 [#1411]: https://github.com/tokio-rs/tracing/pull/1411
+
 [#1327]: https://github.com/tokio-rs/tracing/pull/1327
 
 # 0.13.0 (May 15, 2021)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-### Changed
-
 - Upgrade from opentelemetry to 0.32.0. Refer to the upstream
-  [changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-sdk/CHANGELOG.md#0320)
+[changelog](https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-sdk/CHANGELOG.md#0320)
 - Update tracing ecosystem dependencies to latest compatible patch versions.
 
 ## [0.32.1](https://github.com/tokio-rs/tracing-opentelemetry/compare/v0.32.0...v0.32.1) - 2025-12-17
@@ -27,8 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Other
 
-- Remove unwanted dependency on opentelemetry sdk
-  crate ([#241](https://github.com/tokio-rs/tracing-opentelemetry/pull/241))
+- Remove unwanted dependency on opentelemetry sdk crate ([#241](https://github.com/tokio-rs/tracing-opentelemetry/pull/241))
 - update README.md links to use the latest version ([#239](https://github.com/tokio-rs/tracing-opentelemetry/pull/239))
 - remove thiserror and unused dependencies ([#238](https://github.com/tokio-rs/tracing-opentelemetry/pull/238))
 
@@ -41,12 +38,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - OpenTelemetry context activation ([#202](https://github.com/tokio-rs/tracing-opentelemetry/pull/202))
-    - Trace ID and span ID can be obtained from `OtelData` via dedicated functions. Note that these
-      will be available only if the context has already been built. (#233)
-- Correctly track entered and exited state for
-  timings ([#212](https://github.com/tokio-rs/tracing-opentelemetry/pull/212))
-- Slightly improve error message on version
-  mismatch ([#211](https://github.com/tokio-rs/tracing-opentelemetry/pull/211))
+  - Trace ID and span ID can be obtained from `OtelData` via dedicated functions. Note that these
+    will be available only if the context has already been built. (#233)
+- Correctly track entered and exited state for timings ([#212](https://github.com/tokio-rs/tracing-opentelemetry/pull/212))
+- Slightly improve error message on version mismatch ([#211](https://github.com/tokio-rs/tracing-opentelemetry/pull/211))
 - Remove Lazy for thread_local static ([#215](https://github.com/tokio-rs/tracing-opentelemetry/pull/215))
 - Update description of special fields and semantic conventions
 
@@ -63,6 +58,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   opentelemetry semantic conventions for code.  ([#209](https://github.com/tokio-rs/tracing-opentelemetry/pull/209))
 - Remove the `metrics_gauge_unstable` feature.
 
+
 # 0.31.0 (June 2, 2025)
 
 ### Breaking Changes
@@ -73,9 +69,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- Add `OpenTelemetrySpanExt::add_event` and `OpenTelemetrySpanExt::add_event_with_timestamp`
-  functions to allow adding OpenTelemetry events directly to a `tracing::Span`, enabling the use of dynamic attribute
-  keys
+- Add `OpenTelemetrySpanExt::add_event` and `OpenTelemetrySpanExt::add_event_with_timestamp` 
+  functions to allow adding OpenTelemetry events directly to a `tracing::Span`, enabling the use of dynamic attribute keys 
   and custom event timestamps.
 
 # 0.30.0 (March 23, 2025)
@@ -232,7 +227,6 @@ This release adds optional support for recording `std::error::Error`s using
 Thanks to @lilymara-onesignal for contributing to this release!
 
 [thread-semconv]: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/exceptions/
-
 [#2135]: https://github.com/tokio-rs/tracing/pull/2135
 
 # 0.17.3 (June 7, 2022)
@@ -271,13 +265,9 @@ Thanks to new contributors @lilymara-onesignal, @hubertbudzynski, and @DevinCarr
 for contributing to this release!
 
 [thread-semconv]: https://opentelemetry.io/docs/reference/specification/trace/semantic_conventions/span-general/#source-code-attributes
-
 [#2134]: https://github.com/tokio-rs/tracing/pull/2134
-
 [#2122]: https://github.com/tokio-rs/tracing/pull/2122
-
 [#2124]: https://github.com/tokio-rs/tracing/pull/2124
-
 [#2099]: https://github.com/tokio-rs/tracing/pull/2099
 
 # 0.17.2 (February 21, 2022)
@@ -290,7 +280,6 @@ This release fixes [an issue][#1944] introduced in v0.17.1 where
 - Compilation failure with `tracing-log` feature disabled ([#1949])
 
 [#1949]: https://github.com/tokio-rs/tracing/pull/1917
-
 [#1944]: https://github.com/tokio-rs/tracing/issues/1944
 
 # 0.17.1 (February 11, 2022) (YANKED)
@@ -301,7 +290,6 @@ This release fixes [an issue][#1944] introduced in v0.17.1 where
   forwarded events (defaults to on) ([#1911])
 - `OpenTelemetryLayer::with_event_location` to control whether source locations
   are recorded ([#1911])
-
 ### Changed
 
 - Avoid unnecessary allocations to improve performance when recording events
@@ -310,7 +298,6 @@ This release fixes [an issue][#1944] introduced in v0.17.1 where
 Thanks to @djc for contributing to this release!
 
 [#1917]: https://github.com/tokio-rs/tracing/pull/1917
-
 [#1911]: https://github.com/tokio-rs/tracing/pull/1911
 
 # 0.17.0 (February 3, 2022)
@@ -337,9 +324,7 @@ Thanks to @djc for contributing to this release!
 Thanks to @LehMaxence for contributing to this release!
 
 [v0.3.0 changelog]: https://github.com/tokio-rs/tracing/releases/tag/tracing-subscriber-0.3.0
-
 [#1516]: https://github.com/tokio-rs/tracing/pull/1516
-
 [#1677]: https://github.com/tokio-rs/tracing/pull/1677
 
 # 0.15.0 (August 7, 2021)
@@ -371,9 +356,7 @@ Thanks to @Drevoed, @lilymara-onesignal, and @Folyd for contributing
 to this release!
 
 [#1441]: https://github.com/tokio-rs/tracing/pull/1441
-
 [#1411]: https://github.com/tokio-rs/tracing/pull/1411
-
 [#1327]: https://github.com/tokio-rs/tracing/pull/1327
 
 # 0.13.0 (May 15, 2021)

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,17 +26,17 @@ opentelemetry = { version = "0.32.0", default-features = false, features = [
     "trace",
 ] }
 
-tracing = { version = "0.1.44", default-features = false, features = ["std"] }
-tracing-core = "0.1.36"
-tracing-subscriber = { version = "0.3.23", default-features = false, features = [
+tracing = { version = "0.1.35", default-features = false, features = ["std"] }
+tracing-core = "0.1.28"
+tracing-subscriber = { version = "0.3.22", default-features = false, features = [
     "registry",
     "std",
 ] }
 tracing-log = { version = "0.2.0", default-features = false, optional = true }
-smallvec = { version = "1.15", optional = true }
+smallvec = { version = "1.0", optional = true }
 
 # Fix minimal-versions
-lazy_static = { version = "1.5.0", optional = true }
+lazy_static = { version = "1.0.2", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false, features = [
@@ -57,12 +57,12 @@ opentelemetry-semantic-conventions = { version = "0.32.0", features = [
     "semconv_experimental",
 ] }
 tokio = { version = "1", features = ["full"] }
-tracing = { version = "0.1.44", default-features = false, features = [
+tracing = { version = "0.1.35", default-features = false, features = [
     "std",
     "attributes",
 ] }
-tracing-error = "0.2.1"
-tracing-subscriber = { version = "0.3.23", default-features = false, features = [
+tracing-error = "0.2.0"
+tracing-subscriber = { version = "0.3.0", default-features = false, features = [
     "registry",
     "std",
     "fmt",
@@ -72,8 +72,8 @@ tracing-subscriber = { version = "0.3.23", default-features = false, features = 
 pprof = { version = "0.15.0", features = ["flamegraph", "criterion"] }
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
-js-sys = "0.3.94"
-web-time = "1.1.0"
+js-sys = "0.3.64"
+web-time = "1.0.0"
 
 [lib]
 bench = false

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,47 +22,47 @@ default = ["tracing-log", "metrics"]
 metrics = ["opentelemetry/metrics", "smallvec"]
 
 [dependencies]
-opentelemetry = { version = "0.31.0", default-features = false, features = [
+opentelemetry = { version = "0.32.0", default-features = false, features = [
     "trace",
 ] }
 
-tracing = { version = "0.1.35", default-features = false, features = ["std"] }
-tracing-core = "0.1.28"
-tracing-subscriber = { version = "0.3.22", default-features = false, features = [
+tracing = { version = "0.1.44", default-features = false, features = ["std"] }
+tracing-core = "0.1.36"
+tracing-subscriber = { version = "0.3.23", default-features = false, features = [
     "registry",
     "std",
 ] }
 tracing-log = { version = "0.2.0", default-features = false, optional = true }
-smallvec = { version = "1.0", optional = true }
+smallvec = { version = "1.15", optional = true }
 
 # Fix minimal-versions
-lazy_static = { version = "1.0.2", optional = true }
+lazy_static = { version = "1.5.0", optional = true }
 
 [dev-dependencies]
 criterion = { version = "0.5.1", default-features = false, features = [
     "html_reports",
 ] }
-opentelemetry = { version = "0.31.0", features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.31.0", default-features = false, features = [
+opentelemetry = { version = "0.32.0", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.32.0", default-features = false, features = [
     "trace",
     "experimental_metrics_custom_reader",
     "testing",
 ] }
-opentelemetry-stdout = { version = "0.31.0", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.31.0", features = [
+opentelemetry-stdout = { version = "0.32.0", features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.32.0", features = [
     "metrics",
     "grpc-tonic",
 ] }
-opentelemetry-semantic-conventions = { version = "0.31.0", features = [
+opentelemetry-semantic-conventions = { version = "0.32.0", features = [
     "semconv_experimental",
 ] }
 tokio = { version = "1", features = ["full"] }
-tracing = { version = "0.1.35", default-features = false, features = [
+tracing = { version = "0.1.44", default-features = false, features = [
     "std",
     "attributes",
 ] }
-tracing-error = "0.2.0"
-tracing-subscriber = { version = "0.3.0", default-features = false, features = [
+tracing-error = "0.2.1"
+tracing-subscriber = { version = "0.3.23", default-features = false, features = [
     "registry",
     "std",
     "fmt",
@@ -72,8 +72,8 @@ tracing-subscriber = { version = "0.3.0", default-features = false, features = [
 pprof = { version = "0.15.0", features = ["flamegraph", "criterion"] }
 
 [target.'cfg(all(target_arch = "wasm32", not(target_os = "wasi")))'.dependencies]
-js-sys = "0.3.64"
-web-time = "1.0.0"
+js-sys = "0.3.94"
+web-time = "1.1.0"
 
 [lib]
 bench = false


### PR DESCRIPTION
## Summary

This PR upgrades `tracing-opentelemetry` dependencies to the OpenTelemetry `0.32.0` line and refreshes related tracing/wasm dependency versions. 

## What changed

- Upgraded OpenTelemetry crates to `0.32.0`:
  - `opentelemetry`
  - `opentelemetry_sdk`
  - `opentelemetry-stdout`
  - `opentelemetry-otlp`
  - `opentelemetry-semantic-conventions`


## Verification

- `cargo check --benches` passes successfully.

## Changelog

- Updated `CHANGELOG.md` under `Unreleased` with dependency upgrade and benchmark compatibility notes.

cc @mladedav 