### PR TITLE
chore: upgrade to opentelemetry v0.32

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ default = ["tracing-log", "metrics"]
 metrics = ["opentelemetry/metrics", "smallvec"]
 
 [dependencies]
-opentelemetry = { version = "0.31.0", default-features = false, features = [
+opentelemetry = { version = "0.32.0", default-features = false, features = [
     "trace",
 ] }
 
@@ -42,18 +42,18 @@ lazy_static = { version = "1.0.2", optional = true }
 criterion = { version = "0.5.1", default-features = false, features = [
     "html_reports",
 ] }
-opentelemetry = { version = "0.31.0", features = ["trace", "metrics"] }
-opentelemetry_sdk = { version = "0.31.0", default-features = false, features = [
+opentelemetry = { version = "0.32.0", features = ["trace", "metrics"] }
+opentelemetry_sdk = { version = "0.32.0", default-features = false, features = [
     "trace",
     "experimental_metrics_custom_reader",
     "testing",
 ] }
-opentelemetry-stdout = { version = "0.31.0", features = ["trace", "metrics"] }
-opentelemetry-otlp = { version = "0.31.0", features = [
+opentelemetry-stdout = { version = "0.32.0", features = ["trace", "metrics"] }
+opentelemetry-otlp = { version = "0.32.0", features = [
     "metrics",
     "grpc-tonic",
 ] }
-opentelemetry-semantic-conventions = { version = "0.31.0", features = [
+opentelemetry-semantic-conventions = { version = "0.32.0", features = [
     "semconv_experimental",
 ] }
 tokio = { version = "1", features = ["full"] }


### PR DESCRIPTION
## Motivation

OpenTelemetry has released v0.32 5 days ago: https://github.com/open-telemetry/opentelemetry-rust/releases/tag/opentelemetry-0.32.0

## Solution

Bumped version to `0.32.0` in Cargo.toml