### PR TITLE
fix!: record unsigned and 128-bit integer fields as integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- record `u64`, `i128` and `u128` fields as OpenTelemetry integers instead of stringifying them,
+  on both events and span attributes. Since `opentelemetry::Value` has no unsigned or 128-bit
+  variant, values outside the `i64` range are still recorded as strings rather than being wrapped
+  or saturated into a wrong number.
+- [**breaking**] `otel.name = <unsigned or 128-bit integer>` no longer sets the span name and is
+  recorded as a plain attribute instead, matching how `otel.name = <i64>` has always behaved.
+
 ## [0.33.0](https://github.com/tokio-rs/tracing-opentelemetry/compare/v0.32.1...v0.33.0) - 2026-05-18
 
 ### Fixed

--- a/src/layer.rs
+++ b/src/layer.rs
@@ -204,6 +204,21 @@ fn str_to_status(s: &str) -> otel::Status {
     }
 }
 
+/// Convert an integer of any width to an OpenTelemetry [`Value`].
+///
+/// [`Value`] has no unsigned or 128-bit variant, so integers outside the `i64` range are recorded
+/// as their `Debug` representation instead of being wrapped or saturated into a wrong number. This
+/// matches the behaviour of `opentelemetry-appender-tracing`.
+fn integer_to_value<T>(value: T) -> Value
+where
+    T: TryInto<i64> + fmt::Debug + Copy,
+{
+    match value.try_into() {
+        Ok(value) => Value::I64(value),
+        Err(_) => Value::String(format!("{value:?}").into()),
+    }
+}
+
 #[derive(Default)]
 struct SpanBuilderUpdates {
     name: Option<Cow<'static, str>>,
@@ -307,6 +322,57 @@ impl field::Visit for SpanEventVisitor<'_, '_> {
                 self.event_builder
                     .attributes
                     .push(KeyValue::new(name, value));
+            }
+        }
+    }
+
+    /// Record events on the underlying OpenTelemetry [`Span`] from `u64` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_u64(&mut self, field: &field::Field, value: u64) {
+        match field.name() {
+            "message" => self.event_builder.name = value.to_string().into(),
+            // Skip fields that are actually log metadata that have already been handled
+            #[cfg(feature = "tracing-log")]
+            name if name.starts_with("log.") => (),
+            name => {
+                self.event_builder
+                    .attributes
+                    .push(KeyValue::new(name, integer_to_value(value)));
+            }
+        }
+    }
+
+    /// Record events on the underlying OpenTelemetry [`Span`] from `i128` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_i128(&mut self, field: &field::Field, value: i128) {
+        match field.name() {
+            "message" => self.event_builder.name = value.to_string().into(),
+            // Skip fields that are actually log metadata that have already been handled
+            #[cfg(feature = "tracing-log")]
+            name if name.starts_with("log.") => (),
+            name => {
+                self.event_builder
+                    .attributes
+                    .push(KeyValue::new(name, integer_to_value(value)));
+            }
+        }
+    }
+
+    /// Record events on the underlying OpenTelemetry [`Span`] from `u128` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_u128(&mut self, field: &field::Field, value: u128) {
+        match field.name() {
+            "message" => self.event_builder.name = value.to_string().into(),
+            // Skip fields that are actually log metadata that have already been handled
+            #[cfg(feature = "tracing-log")]
+            name if name.starts_with("log.") => (),
+            name => {
+                self.event_builder
+                    .attributes
+                    .push(KeyValue::new(name, integer_to_value(value)));
             }
         }
     }
@@ -529,6 +595,27 @@ impl field::Visit for SpanAttributeVisitor<'_> {
     /// [`Span`]: opentelemetry::trace::Span
     fn record_i64(&mut self, field: &field::Field, value: i64) {
         self.record(KeyValue::new(field.name(), value));
+    }
+
+    /// Set attributes on the underlying OpenTelemetry [`Span`] from `u64` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_u64(&mut self, field: &field::Field, value: u64) {
+        self.record(KeyValue::new(field.name(), integer_to_value(value)));
+    }
+
+    /// Set attributes on the underlying OpenTelemetry [`Span`] from `i128` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_i128(&mut self, field: &field::Field, value: i128) {
+        self.record(KeyValue::new(field.name(), integer_to_value(value)));
+    }
+
+    /// Set attributes on the underlying OpenTelemetry [`Span`] from `u128` values.
+    ///
+    /// [`Span`]: opentelemetry::trace::Span
+    fn record_u128(&mut self, field: &field::Field, value: u128) {
+        self.record(KeyValue::new(field.name(), integer_to_value(value)));
     }
 
     /// Set attributes on the underlying OpenTelemetry [`Span`] from `&str` values.
@@ -1646,6 +1733,14 @@ mod tests {
         }
     }
 
+    fn event_attributes(event: &otel::Event) -> HashMap<String, Value> {
+        event
+            .attributes
+            .iter()
+            .map(|kv| (kv.key.to_string(), kv.value.clone()))
+            .collect()
+    }
+
     impl opentelemetry::trace::Tracer for TestTracer {
         type Span = opentelemetry_sdk::trace::Span;
 
@@ -1920,6 +2015,153 @@ mod tests {
         assert_eq!(iter.next().unwrap().name, "exception"); // error attribute is handled specially
         assert_eq!(iter.next().unwrap().name, "field3"); // message attribute is handled specially
         assert_eq!(iter.next().unwrap().name, "event name 5"); // name attribute should not conflict with event name.
+    }
+
+    #[test]
+    fn records_integer_event_fields() {
+        let mut tracer = TestTracer::default();
+        let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug_span!("test span").in_scope(|| {
+                tracing::info!(
+                    signed = -1i64,
+                    unsigned = 1u64,
+                    usize = 2usize,
+                    signed_128 = -3i128,
+                    unsigned_128 = 4u128,
+                    huge_unsigned = u64::MAX,
+                    huge_signed_128 = i128::MIN,
+                    huge_unsigned_128 = u128::MAX,
+                    "an event"
+                );
+            });
+        });
+
+        let events = tracer.with_data(|data| data.events.clone());
+        let attributes = event_attributes(events.iter().next().expect("no events recorded"));
+
+        assert_eq!(attributes["signed"], Value::I64(-1));
+        assert_eq!(attributes["unsigned"], Value::I64(1));
+        assert_eq!(attributes["usize"], Value::I64(2));
+        assert_eq!(attributes["signed_128"], Value::I64(-3));
+        assert_eq!(attributes["unsigned_128"], Value::I64(4));
+
+        // Integers that don't fit into an `i64` are recorded as strings rather than being wrapped
+        // or saturated into a wrong number.
+        assert_eq!(
+            attributes["huge_unsigned"],
+            Value::String(u64::MAX.to_string().into())
+        );
+        assert_eq!(
+            attributes["huge_signed_128"],
+            Value::String(i128::MIN.to_string().into())
+        );
+        assert_eq!(
+            attributes["huge_unsigned_128"],
+            Value::String(u128::MAX.to_string().into())
+        );
+    }
+
+    #[test]
+    fn records_integer_message_event_field() {
+        let mut tracer = TestTracer::default();
+        let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug_span!("test span").in_scope(|| {
+                tracing::event!(tracing::Level::INFO, message = 5u64);
+                tracing::event!(tracing::Level::INFO, message = 6i128);
+                tracing::event!(tracing::Level::INFO, message = 7u128);
+            });
+        });
+
+        let events = tracer.with_data(|data| data.events.clone());
+
+        for (event, expected) in events.iter().zip(["5", "6", "7"]) {
+            assert_eq!(event.name, expected);
+            assert!(!event_attributes(event).contains_key("message"));
+        }
+    }
+
+    #[test]
+    #[cfg(feature = "tracing-log")]
+    fn drops_integer_log_metadata_event_fields() {
+        let mut tracer = TestTracer::default();
+        let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug_span!("test span").in_scope(|| {
+                tracing::info!(log.line = 42u64, log.column = 1u128, "an event");
+            });
+        });
+
+        let events = tracer.with_data(|data| data.events.clone());
+        let attributes = event_attributes(events.iter().next().expect("no events recorded"));
+
+        assert!(!attributes.contains_key("log.line"));
+        assert!(!attributes.contains_key("log.column"));
+    }
+
+    #[test]
+    fn records_integer_span_fields() {
+        let mut tracer = TestTracer::default();
+        let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            let span = tracing::debug_span!(
+                "test span",
+                signed = -1i64,
+                unsigned = 1u64,
+                usize = 2usize,
+                signed_128 = -3i128,
+                unsigned_128 = 4u128,
+                huge_unsigned = u64::MAX,
+                huge_signed_128 = i128::MIN,
+                huge_unsigned_128 = u128::MAX,
+                recorded = tracing::field::Empty,
+            );
+            span.record("recorded", 8usize);
+        });
+
+        let attributes = tracer.attributes();
+
+        assert_eq!(attributes["signed"], Value::I64(-1));
+        assert_eq!(attributes["unsigned"], Value::I64(1));
+        assert_eq!(attributes["usize"], Value::I64(2));
+        assert_eq!(attributes["signed_128"], Value::I64(-3));
+        assert_eq!(attributes["unsigned_128"], Value::I64(4));
+        assert_eq!(attributes["recorded"], Value::I64(8));
+
+        // Integers that don't fit into an `i64` are recorded as strings rather than being wrapped
+        // or saturated into a wrong number.
+        assert_eq!(
+            attributes["huge_unsigned"],
+            Value::String(u64::MAX.to_string().into())
+        );
+        assert_eq!(
+            attributes["huge_signed_128"],
+            Value::String(i128::MIN.to_string().into())
+        );
+        assert_eq!(
+            attributes["huge_unsigned_128"],
+            Value::String(u128::MAX.to_string().into())
+        );
+    }
+
+    #[test]
+    fn records_integer_otel_span_fields_as_attributes() {
+        let mut tracer = TestTracer::default();
+        let subscriber = tracing_subscriber::registry().with(layer().with_tracer(tracer.clone()));
+
+        tracing::subscriber::with_default(subscriber, || {
+            tracing::debug_span!("test span", otel.name = 5u64);
+        });
+
+        // Just like `otel.name = 5i64`, an unsigned integer is a plain attribute: signedness must
+        // not change how a field is handled.
+        assert_eq!(tracer.with_data(|data| data.name.clone()), "test span");
+        assert_eq!(tracer.attributes()["otel.name"], Value::I64(5));
     }
 
     #[test]


### PR DESCRIPTION
## Motivation

`u64`, `i128` and `u128` fields are not visited at all, so they fall back to
`record_debug` and reach the collector as strings. `#[instrument]` on a function
taking a `usize` or a `u64`, a `span.record("len", buf.len())`, or a plain
`info!(bytes = n)` all produce a string attribute today, while the same value as
an `i64` produces a number. Downstream that means no range queries, no
aggregations, and — in schema-inferring backends — a field whose type flips
between documents.

For `u64` this is a regression rather than a gap:

* [tokio-rs/tracing#1007] added `record_u64` to both visitors, for exactly this
  reason ("I noticed all the data gets sent to the collector as a string").
* [tokio-rs/tracing#1049], the OpenTelemetry 0.10 upgrade, removed it again with
  the note "Record `u64` values as strings as they are no longer supported in
  OpenTelemetry", because `Value::U64` had disappeared from the otel API.

That removal was the right call with the options available at the time: the
alternatives were `as i64` (wraps large values into negative numbers) or
stringify everything. Since then `opentelemetry-appender-tracing` has settled on
a third option — try the conversion, fall back to a string only when it fails —
which keeps the honest rendering for the unrepresentable case that motivated the
removal, without paying for it on the values that do fit.

[tokio-rs/tracing#1007]: https://github.com/tokio-rs/tracing/pull/1007
[tokio-rs/tracing#1049]: https://github.com/tokio-rs/tracing/pull/1049

## Solution

Implement `record_u64`, `record_i128` and `record_u128` on both `SpanEventVisitor`
and `SpanAttributeVisitor`, going through a shared helper: `i64::try_from` →
`Value::I64`, and the `Debug` rendering on failure. Not `as i64`, and not
saturating — the fallback is unreachable for every value that fits, and when it
isn't reached, it should not report a confidently wrong number. This matches
[`opentelemetry-appender-tracing`][appender], which does the same for the same
reason.

`record_bytes` is deliberately left alone: `opentelemetry::Value` has no bytes
variant, so the hex string is the honest rendering there too.

The new event methods keep both leading arms of the existing ones, so `message`
still sets the event name instead of pushing an attribute, and `log.*` fields are
still dropped as already-handled log metadata under the `tracing-log` feature —
worth noting because `log.line` arrives precisely as a `u64`.

### Breaking change

Context, since it's easy to forget: the `otel.*` special-casing lives only in
`record_str` and `record_debug`. `record_i64` doesn't have it and records a
plain attribute like any other field. So `otel.name = 5u64` renames the span
today only because there was no `record_u64` and the value fell through to
`record_debug`, while `otel.name = 5i64` has always been an attribute.

Now that `record_u64` exists, the unsigned case lands where the signed one
already did: `otel.name = <unsigned or 128-bit integer>` becomes a plain
attribute and no longer renames the span. Only callers naming a span after an
unsigned number are affected; a `&str` `otel.name` is untouched. The other three
control fields lose nothing real — `str_to_status` only accepts `"ok"`/`"error"`
and `str_to_span_kind` only the five kind names, so a numeric
`otel.status_code` or `otel.kind` already resolved to a no-op.

I followed `record_i64` rather than copying the `otel.*` arms into the new
methods, on the grounds that signedness shouldn't change what a field means —
happy to flip it if you'd rather keep the rename. It also interacts with #217,
which would put `otel.*` handling on events as well.

[appender]: https://github.com/open-telemetry/opentelemetry-rust/blob/main/opentelemetry-appender-tracing/src/layer.rs

## Tests

Five new tests, since the attribute *type* is what nothing asserted for years:
each integer width lands as `Value::I64` on both events and span attributes
(including `span.record` after the fact, and `usize`, which routes through
`record_u64`); `u64::MAX` / `i128::MIN` / `u128::MAX` fall back to strings;
`message = 5u64` sets the event name and records no `message` attribute;
`log.*` integer fields are still dropped under `tracing-log`; and
`otel.name = 5u64` is recorded as an attribute without touching the span name.
